### PR TITLE
0.0.81 Prefix fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - handle dynamic styling 
 
+### 0.0.81
+
+- Fix: allow for brackets/spaces before/after prefixes
 
 ### 0.0.8
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tailwind Sorter",
   "description": "Sort your tailwind classes in a predictable way",
   "icon": "icon.png",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "pricing": "Free",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -19,10 +19,11 @@ export function createRegex() {
 
   const prefixes = `(${escapedPrefixes}|class=|className=)`;
 
-  // regex101 example: https://regex101.com/r/81bCmO/1
-  // (?<=\\s|^) prefix should be preceded by a space or the start of the string
+  // regex101 example: https://regex101.com/r/IfViQ8/1
+  // (?<=\\s|{|^) prefix should be preceded by a space, bracket, or the start of the string
+  // \\s* may have spaces/newlines after the prefix
   // "([^"?<{>]*)" matches everything inside quotes group unless there is dynamic syntax inside
-  const regexStr = `(?<=\\s|^)${prefixes}("([^"?<{>]*)"|'([^'?<{>]*)'|\`([^\`?<{>]*)\`)`;
+  const regexStr = `(?<=\\s|{|^)${prefixes}\\s*("([^"?<{>]*)"|'([^'?<{>]*)'|\`([^\`?<{>]*)\`)`;
 
   return new RegExp(regexStr, "g");
 }

--- a/src/test/regex.test.ts
+++ b/src/test/regex.test.ts
@@ -61,10 +61,38 @@ suite("Custom Prefixes", () => {
     assert.strictEqual(group, correctMatch);
   }
 
+  test(`Newline twMerge(`, () => {
+    checkEquals(
+      `const classes = {
+  container: twMerge(
+    "flex flex-col items-stretch mt-4 text-[20px] lg:text-red-500"
+  ),
+};`,
+      "flex flex-col items-stretch mt-4 text-[20px] lg:text-red-500"
+    );
+  });
+
   test(`twMerge(`, () => {
     checkEquals(
       `<div blah blah blah twMerge("relative before:rounded-full before:content-[''] before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl") blah >`,
       "relative before:rounded-full before:content-[''] before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl"
+    );
+  });
+
+  test(`Inside brackets twMerge(`, () => {
+    checkEquals(
+      `<aside className={twMerge('fixed bottom-0 right-0 p-4')}>`,
+      "fixed bottom-0 right-0 p-4"
+    );
+  });
+
+  test(`Multiline brackets twMerge(`, () => {
+    checkEquals(
+      `className={twMerge(
+        "relative h-full font-sans antialiased", 
+        inter.className
+        )}>`,
+      "relative h-full font-sans antialiased"
     );
   });
 
@@ -79,6 +107,28 @@ suite("Custom Prefixes", () => {
     checkEquals(
       `<div blah blah blah clsx('relative before:rounded-full before:content-[""] before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl') blah >`,
       'relative before:rounded-full before:content-[""] before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl'
+    );
+  });
+
+  test(`Newline clsx(`, () => {
+    checkEquals(
+      `<span
+        className={clsx(
+          "px-2 items-center rounded-full inline-flex py-1 text-sm",
+          {
+            "bg-gray-100 text-gray-500": status === "pending",
+            "bg-green-500 text-white": status === "paid",
+          }
+        )}
+      ></span>`,
+      "px-2 items-center rounded-full inline-flex py-1 text-sm"
+    );
+  });
+
+  test(`Whitespace clsx(`, () => {
+    checkEquals(
+      `clsx(   'text-base          bg-blue-500          ')`,
+      "text-base          bg-blue-500          "
     );
   });
 

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -68,6 +68,16 @@ suite("Sorting", () => {
     );
   });
 
+  test("Dot in class", () => {
+    const sortedString = `class="bg-[url('image.jpg')] text-black"`;
+    const unsortedString = `class="text-black bg-[url('image.jpg')]"`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("Negative margins", () => {
     const sortedString = `<div className='z-10 -mt-5 -mb-5' blah blah`;
     const unsortedString = `<div className='-mb-5 z-10 -mt-5' blah blah`;

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -180,6 +180,70 @@ suite("Sorting", () => {
     );
   });
 
+  test(`Inside brackets twMerge(`, () => {
+    const sortedString = `<aside className={twMerge('flex p-4')}>`;
+    const unsortedString = `<aside className={twMerge(' p-4     flex    ')}>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test(`Inside brackets w space twMerge(`, () => {
+    const sortedString = `<aside className={ twMerge('flex p-4')}>`;
+    const unsortedString = `<aside className={ twMerge(' p-4     flex    ')}>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test(`Newline twMerge(`, () => {
+    const sortedString = `const classes = {
+      container: twMerge(
+        "grid-cols-2 lg:grid-cols-[1fr, auto]"
+      ),
+    };`;
+    const unsortedString = `const classes = {
+      container: twMerge(
+        "lg:grid-cols-[1fr, auto] grid-cols-2"
+      ),
+    };`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test(`Complex newline clsx(`, () => {
+    const sortedString = `<span
+        className={clsx(
+          "px-2 py-1",
+          {
+            "bg-gray-100 text-gray-500": status === "pending",
+            "bg-green-500 text-white": status === "paid",
+          }
+        )}
+      ></span>`;
+    const unsortedString = `<span
+        className={clsx(
+          "py-1 px-2",
+          {
+            "bg-gray-100 text-gray-500": status === "pending",
+            "bg-green-500 text-white": status === "paid",
+          }
+        )}
+      ></span>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("clsx multi", () => {
     // https://github.com/lukeed/clsx#readme
     // ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
@@ -195,7 +259,7 @@ suite("Sorting", () => {
 
   test("clsx", () => {
     const sortedString = `clsx('bg-blue-500 text-base')`;
-    const unsortedString = `clsx('text-base bg-blue-500')`;
+    const unsortedString = `clsx('text-base           bg-blue-500     ')`;
 
     assert.strictEqual(
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),


### PR DESCRIPTION
- fix: allow brackets/spaces before\after prefixes as in: `className={twMerge(  'flex p-4')}>`
- add more test cases