### PR TITLE
Fix: empty strings block sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - handle dynamic styling 
 
+### 0.0.84
+
+- Fix: stop empty strings from preventing class sorting
+
 ### 0.0.83
 
 - Add Rust target language

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tailwind Sorter",
   "description": "Sort your tailwind classes in a predictable way",
   "icon": "icon.png",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "pricing": "Free",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -28,15 +28,15 @@ export default function sortTailwind(
       const quotesGroup =
         singleQuotesGroup || doubleQuotesGroup || backtickQuotesGroup;
 
+      if (!quotesGroup) {
+        return match;
+      }
+
       const groupContainsDynamicSyntax = dynamicSyntaxMarkers.some((syntax) =>
         quotesGroup.includes(syntax)
       );
 
-      if (
-        !quotesGroup ||
-        !quotesGroup.includes(" ") ||
-        groupContainsDynamicSyntax
-      ) {
+      if (!quotesGroup.includes(" ") || groupContainsDynamicSyntax) {
         return match;
       }
 

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -38,6 +38,26 @@ suite("Sorting", () => {
     );
   });
 
+  test("Empty string present", () => {
+    const sortedString = `<div className=''></div><div className='flex flex-col' blah blah`;
+    const unsortedString = `<div className=''></div><div className='flex-col flex' blah blah`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test("Multi string types", () => {
+    const sortedString = `<div className="flex flex-col"></div><div className='flex flex-col' blah blah`;
+    const unsortedString = `<div className="flex-col flex"></div><div className='flex-col flex' blah blah`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("Repeat classes", () => {
     const sortedString = `<div className="top-0 left-0 left-0 left-10 lg:static fixed flex justify-center"`;
     const unsortedString = `<div className="top-0 left-10 left-0 lg:static fixed flex justify-center left-0"`;


### PR DESCRIPTION
- Empty string values (undefined) passed into the dynamic syntax matcher broke sorting
- Checking for undefined values and returning earlier fixes this

``` typescript
<div className=""></div> // would break here
<div className='flex flex-col'></div> // not sorted
```
