### PR TITLE
Maintain non-tailwind classes sort order

### DIFF
--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -69,29 +69,38 @@ function sortFoundTailwind(
     return match;
   }
 
-  const unsortedClasses = classesStr
+  const classes = classesStr
     .split(/\s+/)
     .filter((className) => className.trim() !== "");
 
-  if (!unsortedClasses.length) {
+  if (!classes.length) {
     return match;
   }
+
+  const { unsortedClasses, nonSortedClasses } = classes.reduce(
+    (acc, className) => {
+      const match = findLongestMatch(className, sortConfig);
+
+      match
+        ? acc.unsortedClasses.push(className)
+        : acc.nonSortedClasses.push(className);
+
+      return acc;
+    },
+    { unsortedClasses: [] as string[], nonSortedClasses: [] as string[] }
+  );
 
   const sortedClasses = unsortedClasses.sort(
     (aClass: string, bClass: string) => {
       const a = findLongestMatch(aClass, sortConfig);
       const b = findLongestMatch(bClass, sortConfig);
 
-      // assign each class its sortConfig index, add .5 if it's a pseudo class,
-      // and default to Number.MAX_VALUE so classes not in sortConfig are placed at the end
       const aIsPseudo = aClass.includes(":");
       const bIsPseudo = bClass.includes(":");
 
-      // nullish coalescing https://www.typescriptlang.org/play/?#example/nullish-coalescing
-      const aIndex =
-        (aIsPseudo ? sortConfig[a] + 0.5 : sortConfig[a]) ?? Number.MAX_VALUE;
-      const bIndex =
-        (bIsPseudo ? sortConfig[b] + 0.5 : sortConfig[b]) ?? Number.MAX_VALUE;
+      // assign each class its sortConfig index, add .5 if it's a pseudo class
+      const aIndex = aIsPseudo ? sortConfig[a] + 0.5 : sortConfig[a];
+      const bIndex = bIsPseudo ? sortConfig[b] + 0.5 : sortConfig[b];
 
       if (aIndex === bIndex) {
         // if same index, sort alphabetically
@@ -112,7 +121,7 @@ function sortFoundTailwind(
     }
   );
 
-  const sortedClassesStr = sortedClasses.join(" ");
+  const sortedClassesStr = [...sortedClasses, ...nonSortedClasses].join(" ");
 
   return match.replace(classesStr, sortedClassesStr);
 }

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -28,6 +28,36 @@ suite("Sorting", () => {
     );
   });
 
+  test("Non tailwind classes keep their sort order", () => {
+    const sortedString = `<div class="flex flex-col flex-1 carrot banana apple" blah blah`;
+    const unsortedString = `<div class="flex-col carrot flex-1 banana flex apple" blah blah`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test("Non tailwind classes w duplicates keep their sort order", () => {
+    const sortedString = `<div class="flex flex-col flex-1 banana carrot-1 carrot-1 hover:carrot apple" blah blah`;
+    const unsortedString = `<div class="banana carrot-1 flex-col carrot-1 hover:carrot flex-1 apple flex" blah blah`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test("Non tailwind classes w prefix keep their sort order", () => {
+    const sortedString = `<div class="tw:px-4 tw-text-2xl foo bar"><div>`;
+    const unsortedString = `<div class="foo bar tw-text-2xl tw:px-4"><div>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("One word sort", () => {
     const sortedString = `<div className='flex' blah blah`;
     const unsortedString = `<div className='flex' blah blah`;


### PR DESCRIPTION
- keep non-tailwind classes sort order the same, instead of sorting alphabetically

``` typescript
// unsorted
<div class="foo bar tw-text-2xl tw:px-4">
// sorted
<div class="tw:px-4 tw-text-2xl foo bar">
```