### PR TITLE
Allow _ Prefix

### DIFF
--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -163,8 +163,9 @@ export function findLongestMatch(
     const keyInStyleClass =
       baseClass.startsWith(key) ||
       baseClass.includes("-" + key) ||
-      baseClass.includes(":" + key) ||
-      baseClass.includes("!" + key);
+      baseClass.includes("!" + key) ||
+      // allow _ prefix for ignored classes
+      baseClass.startsWith("_" + key);
 
     if (keyInStyleClass && key.length > longestMatch.length) {
       longestMatch = key;

--- a/src/test/config-match.test.ts
+++ b/src/test/config-match.test.ts
@@ -18,8 +18,24 @@ suite("Find Config Match", () => {
     assert.strictEqual(findLongestMatch("shape-wrapper", classesMap), "");
   });
 
+  test("custom_flex", () => {
+    assert.strictEqual(findLongestMatch("custom_flex", classesMap), "");
+  });
+
+  test("_custom_flex", () => {
+    assert.strictEqual(findLongestMatch("_custom_flex", classesMap), "");
+  });
+
   test("pe-4", () => {
     assert.strictEqual(findLongestMatch("pe-4", classesMap), "pe-");
+  });
+
+  test("_ prefix for ignored classes", () => {
+    assert.strictEqual(findLongestMatch("_ml-5", classesMap), "ml-");
+  });
+
+  test("_ prefix for ignored classes w pseudos", () => {
+    assert.strictEqual(findLongestMatch("_hover:ml-5", classesMap), "ml-");
   });
 
   test("-ml-5", () => {

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -666,6 +666,16 @@ suite("Sorting", () => {
       sortedString
     );
   });
+
+  test("allow _ prefix for ignored classes", () => {
+    const sortedString = `<div class="flex _flex-col justify-center gap-6 bg-white _shadow-2xl p-8 border _hover:border-yellow-400 rounded-4xl w-lg custom_flex">`;
+    const unsortedString = `<div class="_shadow-2xl justify-center custom_flex gap-6 _hover:border-yellow-400 bg-white _flex-col p-8 border flex rounded-4xl w-lg">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
 });
 
 suite("@apply Sorting", () => {


### PR DESCRIPTION
- allow classes with `_` prefixes to sort as normal
  - use case: ignore tailwind classes without losing their sorting