### PR TITLE
0.1.36 EJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+#### 0.1.36
+
+- Add EJS target language
+
 #### 0.1.35
 
 - Add MDX target language

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Single line `@apply` rules ending with a semicolon that do not include dynamic s
 
 #### Language Support
 
-Currently, Tailwind Sorter supports `.html`, `.jsx`, `.tsx`, `mdx`, `.ex`, `.heex`, `.twig`, `.svelte`, `.vue`, `php`, `.rb`, `.erb`, `.rs`, `.css`, `.scss`, and `.astro` files. If you would like to see support for an additional language, please open an issue (or submit a PR).
+Currently, Tailwind Sorter supports `.html`, `.jsx`, `.tsx`, `ejs`, `mdx`, `.ex`, `.heex`, `.twig`, `.svelte`, `.vue`, `php`, `.rb`, `.erb`, `.rs`, `.css`, `.scss`, and `.astro` files. If you would like to see support for an additional language, please open an issue (or submit a PR).
 
 #### With Prettier
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-sorter",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-sorter",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tailwind Sorter",
   "description": "Sort your tailwind classes in a predictable way",
   "icon": "icon.png",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "pricing": "Free",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -2,6 +2,7 @@ export const languages = [
   "html",
   "javascriptreact",
   "typescriptreact",
+  "ejs",
   "astro",
   "svelte",
   "vue",

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -62,6 +62,7 @@ export const dynamicSyntaxMarkers = [
   "}}",
   "<%",
   "<%=",
+  "<%-",
   "%>",
   "<?php",
   "<?=",

--- a/src/test/sorting-ignore.test.ts
+++ b/src/test/sorting-ignore.test.ts
@@ -166,6 +166,52 @@ suite("Ignore sorting", () => {
     );
   });
 
+  test("EJS dynamic syntax: do not change", () => {
+    const unsortedString = `<% const isError = true; %>
+<div class="<%= isError ? 'bg-red-100 text-red-800' : 'bg-green-100 text-green-800' %> px-4 py-2 rounded">
+  <%= isError ? 'There was an error!' : 'All good!' %>
+</div>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
+  test("EJS array join: do not change", () => {
+    const unsortedString = `<%
+  const classes = [
+    'px-4', 'py-2', 'rounded',
+    isError ? 'bg-red-100 text-red-800' : 'bg-green-100 text-green-800',
+    isActive && 'border-2 border-blue-500'
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%= classes %>"></div>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
+  test("EJS include: do not change", () => {
+    const unsortedString = `<%- include('components/button', { className: 'bg-blue-500 text-white' }) %>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
+  test("EJS unescaped class: do not change", () => {
+    const unsortedString = `<div class="<%- someClass %> px-4 py-2 rounded"></div>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
   test("Alpine.js syntax: do not change", () => {
     const unsortedString = `<div x-data="{ isPrimary: true, isActive: true }"`;
 

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -414,6 +414,20 @@ This is a **bold** paragraph.
     );
   });
 
+  test("EJS syntax", () => {
+    const sortedString = `<% for (let i = 1; i <= 20; i++) { %>
+        <p class="text-gray-700 text-sm">Item <%= i %></p>
+      <% } %>`;
+    const unsortedString = `<% for (let i = 1; i <= 20; i++) { %>
+        <p class="text-sm text-gray-700">Item <%= i %></p>
+      <% } %>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("Angular syntax", () => {
     const sortedString = `<div class="bg-blue-500 text-white"`;
     const unsortedString = `<div class="text-white bg-blue-500"`;


### PR DESCRIPTION
- add support for ejs language
  - `.ejs` files that are not recognized as ejs should still be sorted as html