### PR TITLE
0.1.37 `cn(`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+#### 0.1.37
+
+- Add `cn(` as default prefix ([milksense](https://github.com/milksense))
+
 #### 0.1.36
 
 - Add EJS target language

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Custom sort order and categories can be configured in settings
     ],
 ```
 
-**Custom Prefixes**: Tailwind Sorter checks for `class=` and `className=` as well as any custom prefixes defined in settings. Default custom prefixes include: `twMerge(`, `cva(`, and `clsx(`
+**Custom Prefixes**: Tailwind Sorter checks for `class=` and `className=` as well as any custom prefixes defined in settings. Default custom prefixes include: `twMerge(`, `cva(`, `clsx(`, and `cn(`
 
 #### Command
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-sorter",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-sorter",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tailwind Sorter",
   "description": "Sort your tailwind classes in a predictable way",
   "icon": "icon.png",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "pricing": "Free",
   "engines": {
     "vscode": "^1.85.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
           "default": [
             "twMerge(",
             "clsx(",
-            "cva("
+            "cva(",
+            "cn("
           ],
           "description": "Custom prefixes to identify tailwind class strings. Example: clsx( or tw="
         },

--- a/src/lib/defaultConfig.ts
+++ b/src/lib/defaultConfig.ts
@@ -1,3 +1,5 @@
+// default configuration comes from package.json contributes configuration
+
 export const defaultConfig = {
   categoryOrder: {
     sortOrder: [

--- a/src/test/regex.test.ts
+++ b/src/test/regex.test.ts
@@ -103,6 +103,34 @@ suite("Custom Prefixes", () => {
     );
   });
 
+  test(`cn(`, () => {
+    checkEquals(
+      `  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />;`,
+      "w-full caption-bottom text-sm"
+    );
+  });
+
+  test(`Single class cn(`, () => {
+    checkEquals(
+      `className={cn("[&_tr]:border-b", className)} `,
+      "[&_tr]:border-b"
+    );
+  });
+
+  test(`Newline cn(`, () => {
+    checkEquals(
+      `   className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}`,
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
+    );
+  });
+
   test(`clsx(`, () => {
     checkEquals(
       `<div blah blah blah clsx('relative before:rounded-full before:content-[""] before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl') blah >`,
@@ -263,5 +291,14 @@ suite("No Match", () => {
     );
     hasMatch("<div class:red=move || count() % 2 == 1 ></div>", false);
     hasMatch("<div class=style::jumbotron/>", false);
+  });
+
+  test(`Ignore cn function`, () => {
+    hasMatch(
+      `export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}`,
+      false
+    );
   });
 });

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -713,6 +713,48 @@ This is a **bold** paragraph.
     );
   });
 
+  test(`cn(`, () => {
+    const sortedString = `<div className={cn("relative w-full overflow-auto", wrapperClassName)}>`;
+    const unsortedString = `<div className={cn("relative overflow-auto w-full", wrapperClassName)}>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test(`Complex cn(`, () => {
+    const sortedString = `  return <tfoot className={cn("bg-muted/50 border-t last:[&>tr]:border-b-0", className)} {...rest} />;`;
+    const unsortedString = `  return <tfoot className={cn("bg-muted/50 border-t last:[&>tr]:border-b-0", className)} {...rest} />;`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test(`Newline cn(`, () => {
+    const sortedString = `<span
+          className={cn(
+"first:mt-0 px-2 py-1",
+className
+)}
+{...props}
+/>]`;
+    const unsortedString = `<span
+          className={cn(
+"py-1 px-2 first:mt-0",
+className
+)}
+{...props}
+/>]`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test(`Complex newline clsx(`, () => {
     const sortedString = `<span
         className={clsx(


### PR DESCRIPTION
- add `cn(` to default prefixes
- `cn(` is a [common convention](https://github.com/search?q=function+cn+path:*.tsx&type=code) for combining `clsx` and `twMerge`

``` tsx
import { clsx } from "clsx";
import { twMerge } from "tailwind-merge";
 
export function cn(...inputs: ClassValue[]): string {
return twMerge(clsx(inputs));
}
```