### PR TITLE
Razor

### DIFF
--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -18,5 +18,6 @@ export const languages = [
   "rust",
   "css",
   "scss",
-  "aspnetcorerazor"
+  "razor",
+  "aspnetcorerazor",
 ];

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -53,6 +53,17 @@ export function createApplyRegex() {
  */
 export const colonRegex = /:(?![^\[\]]*\])/g;
 
+/**
+ * Finds all parenthesis that are not inside square brackets.
+ * Preserves arbitrary values
+ *
+ * @example
+ * // matches "(" that aren't inside []
+ * // class="@string.Join(" ", classes)"
+ * @see https://regex101.com/r/isai9V/1
+ */
+export const parenthesis = /\((?![^\[\]]*\])/g;
+
 export const dynamicSyntaxMarkers = [
   "${",
   "#{",
@@ -69,4 +80,5 @@ export const dynamicSyntaxMarkers = [
   "?>",
   "{%",
   "%}",
+  "@(",
 ];

--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -3,6 +3,7 @@ import {
   createRegex,
   colonRegex,
   dynamicSyntaxMarkers,
+  parenthesis,
 } from "./lib/regex";
 
 /**
@@ -62,8 +63,8 @@ function sortFoundTailwind(
     return match;
   }
 
-  const groupContainsDynamicSyntax = dynamicSyntaxMarkers.some((syntax) =>
-    classesStr.includes(syntax)
+  const groupContainsDynamicSyntax = dynamicSyntaxMarkers.some(
+    (syntax) => classesStr.includes(syntax) || parenthesis.test(classesStr)
   );
 
   if (groupContainsDynamicSyntax) {

--- a/src/test/regex.test.ts
+++ b/src/test/regex.test.ts
@@ -58,6 +58,23 @@ suite("Correct Regex", () => {
       `bg-blue-400 text-white bg-blue-500`
     );
   });
+
+  test("Arbitrary Variables", () => {
+    checkEquals(
+      `<div class="mt-[calc(theme(spacing.4)+10px)]"></div>`,
+      `mt-[calc(theme(spacing.4)+10px)]`
+    );
+
+    checkEquals(
+      `<div class="clip-path-[polygon(0%_0%,100%_0%,100%_100%,0%_100%)]"></div>`,
+      `clip-path-[polygon(0%_0%,100%_0%,100%_100%,0%_100%)]`
+    );
+
+    checkEquals(
+      `<div class="blur-[calc(1rem+2px)]"></div>`,
+      `blur-[calc(1rem+2px)]`
+    );
+  });
 });
 
 suite("Custom Prefixes", () => {
@@ -249,6 +266,13 @@ suite("No Match", () => {
 
   test(`Ignore dynamic PHP <?= `, () => {
     hasMatch('<div class="<?= $themeClass ?> p-6 rounded-lg">', false);
+  });
+
+  test(`Ignore dynamic Razor @( `, () => {
+    hasMatch(
+      `<div class="p-4 @(isActive ? 'bg-green-200' : 'bg-gray-200')">`,
+      false
+    );
   });
 
   test("Ignore dynamic Svelte", () => {

--- a/src/test/sorting-ignore.test.ts
+++ b/src/test/sorting-ignore.test.ts
@@ -568,6 +568,33 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     );
   });
 
+  test("C# Razor dynamic syntax .Join(: do not change", () => {
+    const unsortedString = `<div class="flex-col @string.Join(" ", classes) flex">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
+  test("C# Razor dynamic syntax @(: do not change", () => {
+    const unsortedString = `<div class="p-4 @(isActive ? "bg-green-200 flex" : "bg-gray-200") flex-col">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
+  test("C# Razor dynamic syntax HTML: do not change", () => {
+    const unsortedString = `@Html.Raw($"<div class=\"p-4 bg-{Model.Color}-500\">Text</div>")`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      unsortedString
+    );
+  });
+
   test("Django dynamic syntax {% %}: do not change", () => {
     const unsortedString = `<div class="bg-{% color %}-500">Hello, world!</div>`;
 

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -536,6 +536,40 @@ This is a **bold** paragraph.
     );
   });
 
+  test("C# Razor syntax", () => {
+    const sortedString = `@model string
+<div class="bg-red-100 p-3 text-red-700">
+    @Model
+</div>`;
+    const unsortedString = `@model string
+<div class="p-3 bg-red-100 text-red-700">
+    @Model
+</div>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test("C# Razor @ syntax", () => {
+    const sortedString = `@for (int i = 0; i < 5; i++)
+{
+    var color = i % 2 == 0 ? "bg-yellow-200" : "bg-pink-200";
+    <div class="mb-2 p-2 rounded @color">Item @i</div>
+}`;
+    const unsortedString = `@for (int i = 0; i < 5; i++)
+{
+    var color = i % 2 == 0 ? "bg-yellow-200" : "bg-pink-200";
+    <div class="mb-2 rounded p-2 @color">Item @i</div>
+}`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("PHP Blade syntax", () => {
     // https://accreditly.io/articles/how-to-use-tailwind-with-blade-components
     const sortedString = `


### PR DESCRIPTION
- support for `aspnetcorerazor` was added in #52 
- add `razor` identifier for `.cshtml` files without extension support
- treat `(` outside of `[]` like dynamic syntax