### PR TITLE
0.1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+#### 0.1.39
+- Fix: sort ruby `.rb` files
+- Match prefixes inside parentheses
+
 #### 0.1.38
 
 - Add Razor target languages ([rintheo](https://github.com/rintheo))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-sorter",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-sorter",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tailwind Sorter",
   "description": "Sort your tailwind classes in a predictable way",
   "icon": "icon.png",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "pricing": "Free",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -13,7 +13,7 @@ export const languages = [
   "twig",
   "elixir",
   "phoenix-heex",
-  "rb",
+  "ruby",
   "erb",
   "rust",
   "css",

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -23,7 +23,7 @@ export function createRegex() {
   // (?<=\\s|{|^) prefix should be preceded by a space, bracket, or the start of the string
   // \\s* may have spaces/newlines after the prefix
   // "([^"?<{]*)" matches everything inside quotes group unless there is dynamic syntax inside
-  const regexStr = `(?<=\\s|{|^)${prefixes}\\s*("([^"?<{]*)"|'([^'?<{]*)'|\`([^\`?<{]*)\`)`;
+  const regexStr = `(?<=\\s|{|^|\\()${prefixes}\\s*("([^"?<{]*)"|'([^'?<{]*)'|\`([^\`?<{]*)\`)`;
 
   return new RegExp(regexStr, "g");
 }

--- a/src/test/regex.test.ts
+++ b/src/test/regex.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import * as sinon from "sinon";
+import { restore } from "sinon";
 
 import { createRegex } from "../lib/regex";
 import createConfigStub from "./_createConfigStub";
@@ -187,7 +187,7 @@ suite("Custom Prefixes", () => {
 
 suite("Non-Default Custom Prefixes", () => {
   teardown(() => {
-    sinon.restore();
+    restore();
   });
 
   test("Potato :)", () => {
@@ -215,6 +215,15 @@ suite("Non-Default Custom Prefixes", () => {
     checkEquals(
       `<%= link_to 'New Frog', new_frog_path, class: 'bg-blue-500 text-white' %>`,
       "bg-blue-500 text-white"
+    );
+  });
+
+  test("Ruby class in parenthesis", () => {
+    createConfigStub({ customPrefixes: ["class:"] });
+
+    checkEquals(
+      `tag.svg(class: "size-full -rotate-90"`,
+      "size-full -rotate-90"
     );
   });
 

--- a/src/test/sorting-ignore.test.ts
+++ b/src/test/sorting-ignore.test.ts
@@ -8,6 +8,10 @@ import createConfigStub from "./_createConfigStub";
 suite("Ignore sorting", () => {
   const { classesMap, pseudoSortOrder } = defaultClassesMap();
 
+  teardown(() => {
+    restore();
+  });
+
   test("Dynamic styles class={` ternary ': do not change", () => {
     const unsortedString =
       "<div class={`button ${isActive ? 'button-active' : 'button-inactive'}`}";
@@ -83,8 +87,6 @@ suite("Ignore sorting", () => {
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       unsortedString
     );
-
-    restore();
   });
 
   test("Dynamic erb helper tag array: do not change", () => {
@@ -96,8 +98,6 @@ suite("Ignore sorting", () => {
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       unsortedString
     );
-
-    restore();
   });
 
   test("Conditional Angular syntax: do not change", () => {

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -11,6 +11,10 @@ import createConfigStub from "./_createConfigStub";
 suite("Sorting", () => {
   const { classesMap, pseudoSortOrder } = defaultClassesMap();
 
+  teardown(() => {
+    restore();
+  });
+
   test('Correct sort class=""', () => {
     const sortedString = `<div class="flex flex-col flex-1 items-center gap-20 bg-black lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 w-full font-sans font-semibold before:content-[''] after:content-['']" blah blah`;
     const unsortedString = `<div class="font-semibold after:content-[''] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[''] items-center" blah blah`;
@@ -607,8 +611,6 @@ This is a **bold** paragraph.
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       sortedString
     );
-
-    restore();
   });
 
   test("Rails erb helper tag with ()", () => {
@@ -621,8 +623,6 @@ This is a **bold** paragraph.
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       sortedString
     );
-
-    restore();
   });
 
   test("Rails rb view component", () => {
@@ -635,8 +635,18 @@ This is a **bold** paragraph.
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       sortedString
     );
+  });
 
-    restore();
+  test("Ruby class: in parenthesis", () => {
+    createConfigStub({ customPrefixes: ["class:"] });
+
+    const sortedString = `tag.svg(class: "flex flex-col size-full -rotate-90", viewBox: "0 0 36 36", xmlns: "http://www.w3.org/2000/svg") do`;
+    const unsortedString = `tag.svg(class: "size-full flex-col -rotate-90 flex", viewBox: "0 0 36 36", xmlns: "http://www.w3.org/2000/svg") do`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
   });
 
   test("Rails rb view component with ()", () => {
@@ -649,8 +659,6 @@ This is a **bold** paragraph.
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       sortedString
     );
-
-    restore();
   });
 
   test("Rails rb view component with special syntax", () => {
@@ -663,8 +671,6 @@ This is a **bold** paragraph.
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),
       sortedString
     );
-
-    restore();
   });
 
   test("Tailwind merge concat strings", () => {


### PR DESCRIPTION
- Fix `.rb` language identifier
- Update regex to grab strings where prefix is inside parentheses
- Remove individual `restore` function calls in favour of suite's `teardown`