### PR TITLE
Stricter class matching

### DIFF
--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -60,7 +60,7 @@ export const colonRegex = /:(?![^\[\]]*\])/g;
  * @example
  * // matches "(" that aren't inside []
  * // class="@string.Join(" ", classes)"
- * @see https://regex101.com/r/isai9V/1
+ * @see https://regex101.com/r/isai9V/2
  */
 export const parenthesis = /\((?![^\[\]]*\])/g;
 

--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -161,10 +161,24 @@ export function findLongestMatch(
 
   let longestMatch = "";
   for (const key in sortConfig) {
+    if (baseClass === key) {
+      return key;
+    }
+
+    // escape chars that could mess with regex
+    const escapedKey = key.replace(/[-[\]\\]/g, "\\$&");
+
+    // can match keys:
+    // starting with `-`, or `!`,
+    // ending with `-` or `/`
+    // ex: invert matches -invert/ but not -inverted/
+    // w lookahead https://regex101.com/r/io1gzM/5
+    // without https://regex101.com/r/DEWLfo/2
+    const lookahead = key.endsWith("-") ? "" : "(?=[-/]|$)";
+    const validSection = new RegExp(`(?<=^|[-!])${escapedKey}${lookahead}`);
+
     const keyInStyleClass =
-      baseClass.startsWith(key) ||
-      baseClass.includes("-" + key) ||
-      baseClass.includes("!" + key) ||
+      validSection.test(baseClass) ||
       // allow _ prefix for ignored classes
       baseClass.startsWith("_" + key);
 

--- a/src/test/config-match.test.ts
+++ b/src/test/config-match.test.ts
@@ -86,6 +86,8 @@ suite("Find Config Match", () => {
       findLongestMatch("hover:!bg-blue-500", classesMap),
       "bg-"
     );
+
+    assert.strictEqual(findLongestMatch("!-m-4", classesMap), "m-");
   });
 
   test("fractions", () => {
@@ -167,20 +169,25 @@ suite("Find Config Match", () => {
     );
   });
 
+  test("bg- custom style class", () => {
+    assert.strictEqual(findLongestMatch("bg-inverted/25", classesMap), "bg-");
+  });
+
+  test("custom style class that includes tailwind in name", () => {
+    assert.strictEqual(findLongestMatch("inverted", classesMap), "");
+  });
+
   test("arbitrary [] class", () => {
     assert.strictEqual(
       findLongestMatch("before:content-[attr(data:time)]", classesMap),
       "content-"
     );
 
+    assert.strictEqual(findLongestMatch("w-[calc(100%/3)]", classesMap), "w-");
+
     assert.strictEqual(
       findLongestMatch("content-['Time:_12:30_PM']", classesMap),
       "content-"
-    );
-
-    assert.strictEqual(
-      findLongestMatch("[&_p]:text-gray-500", classesMap),
-      "text-"
     );
   });
 
@@ -192,6 +199,21 @@ suite("Find Config Match", () => {
 
     assert.strictEqual(
       findLongestMatch("[&:nth-child(3)]:bg-blue-500", classesMap),
+      "bg-"
+    );
+
+    assert.strictEqual(
+      findLongestMatch("[&:is(button,a)]:text-blue-500", classesMap),
+      "text-"
+    );
+
+    assert.strictEqual(
+      findLongestMatch("[&_p]:text-gray-500", classesMap),
+      "text-"
+    );
+
+    assert.strictEqual(
+      findLongestMatch("[&:hover]:[&>*]:bg-red-500", classesMap),
       "bg-"
     );
   });

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -35,6 +35,17 @@ suite("Sorting", () => {
     );
   });
 
+  test("Kitchen sink", () => {
+    const unsortedString = `<div class="text-center after:content-[''] sm:hover:bg-[url('/noise.png')] border-4 -mt-2 hover:focus:rotate-3 lg:dark:bg-gradient-to-tr translate-x-1/2 before:opacity-50 w-[calc(100%-4rem)] flex-col focus-within:ring-4 grid-cols-3 h-screen text-3xl font-black absolute justify-between sm:peer-checked:translate-y-3 hover:skew-x-6 md:max-w-3xl text-blue-500 bg-cover md:grid p-10 bg-center flex bg-no-repeat underline gap-6 sm:w-1/2 sm:bg-yellow-400 bg-[radial-gradient(circle_at_top_left,#1e3a8a,#9333ea)] z-50 sticky rounded-xl hover:contrast-125 hover:shadow-2xl lg:mt-10 lg:pl-8 group-hover:opacity-90 sm:even:translate-x-4 sm:hover:scale-105 text-balance peer-invalid:ring-red-500 overflow-hidden min-h-[50vh] md:py-12 dark:hover:brightness-75 bg-fixed hover:text-white sm:dark:text-green-400 before:absolute sm:translate-x-2 sm:text-lg md:backdrop-blur-xl select-none" blah blah>`;
+
+    const sortedString = `<div class="z-50 absolute before:absolute sticky flex flex-col justify-between gap-6 md:grid grid-cols-3 bg-[radial-gradient(circle_at_top_left,#1e3a8a,#9333ea)] sm:bg-yellow-400 sm:hover:bg-[url('/noise.png')] lg:dark:bg-gradient-to-tr bg-cover bg-no-repeat bg-center bg-fixed before:opacity-50 group-hover:opacity-90 hover:shadow-2xl md:backdrop-blur-xl dark:hover:brightness-75 -mt-2 lg:mt-10 p-10 md:py-12 lg:pl-8 border-4 rounded-xl focus-within:ring-4 peer-invalid:ring-red-500 w-[calc(100%-4rem)] sm:w-1/2 md:max-w-3xl h-screen min-h-[50vh] overflow-hidden font-black text-blue-500 sm:dark:text-green-400 hover:text-white sm:text-lg text-3xl text-center underline text-balance after:content-[''] hover:focus:rotate-3 sm:hover:scale-105 hover:skew-x-6 translate-x-1/2 sm:even:translate-x-4 sm:peer-checked:translate-y-3 sm:translate-x-2 select-none hover:contrast-125" blah blah>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
   test("Non tailwind classes with - sort to end", () => {
     const sortedString = `<div className='relative flex justify-center self-center lg:self-start -ml-5 lg:ml-0 w-[375px] lg:w-[568px] h-[375px] lg:h-[568px] custom shape-wrapper'`;
     const unsortedString = `<div className='lg:self-start -ml-5 relative justify-center custom self-center lg:ml-0 shape-wrapper w-[375px] lg:w-[568px] h-[375px] lg:h-[568px] flex'`;
@@ -66,8 +77,19 @@ suite("Sorting", () => {
   });
 
   test("Non tailwind classes w prefix keep their sort order", () => {
+    // https://v2.tailwindcss.com/docs/configuration#prefix
     const sortedString = `<div class="tw:px-4 tw-text-2xl foo bar"><div>`;
     const unsortedString = `<div class="foo bar tw-text-2xl tw:px-4"><div>`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortedString
+    );
+  });
+
+  test("Custom color shares name with tailwind class", () => {
+    const sortedString = `<div className='flex bg-blue-500 bg-inverted/25 bg-white grayscale invert' blah blah`;
+    const unsortedString = `<div className='flex grayscale bg-white bg-inverted/25 bg-blue-500 invert' blah blah`;
 
     assert.strictEqual(
       sortTailwind(unsortedString, classesMap, pseudoSortOrder),


### PR DESCRIPTION
Previously, custom styles and colours that contained a tailwind class in their name (ex `bg-inverted/50` and `inverted` contain `invert`) would be sorted to the tailwind classes place instead of their own

- replace permissive class matching with regex