### PR TITLE
Include Languages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,7 @@ Example PR: [Adding EJS Support](https://github.com/dejmedus/tailwind-sorter/pul
 
 #### 1. Add the VS Code Language Identifier
 
-Find the language identifier in bottom-right corner of VS Code or via the command palette with `Change Language Mode`
-and add it to the supported languages list
+Find the language identifier via the command palette with `Change Language Mode` and add it to the supported languages list. Identifiers are all lowercase and do not include spaces
 
 ```ts
 // lib/languages.ts

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Custom sort order and categories can be configured in settings
 - [Categories](vscode://settings/tailwindSorter.categories): Which style classes will belong to which category and in what order.
 - [Pseudo Classes Order](vscode://settings/tailwindSorter.pseudoClassesOrder): How pseudo-classes should be ordered.
 - [Custom Prefixes](vscode://settings/tailwindSorter.customPrefixes): Prefixes that identify class strings other than the default `class=` and `className=`.
+- [Include Languages](vscode://settings/tailwindSorter.includeLanguages): Language identifiers to add to the list of supported languages. May not sort as expected.
 - [Sort on Save](vscode://settings/tailwindSorter.sortOnSave): Whether or not classes should be sorted on save.
 
 
@@ -70,6 +71,8 @@ Single line `@apply` rules ending with a semicolon that do not include dynamic s
 #### Language Support
 
 Currently, Tailwind Sorter supports `.html`, `.jsx`, `.tsx`, `.ejs`, `.mdx`, `.ex`, `.heex`, `.twig`, `django-html`, `.svelte`, `.vue`, `.php`, `.blade.php`, `.rb`, `.erb`, `liquid`, `.rs`, `.cshtml`, `.css`, `.scss`, and `.astro` files. If you would like to see support for an additional language, please open an issue (or [submit a PR](/CONTRIBUTING.md)).
+
+Alternatively, you can add additional [language identifiers](./CONTRIBUTING.md#1-add-the-vs-code-language-identifier) to the [Include Languages](vscode://settings/tailwindSorter.includeLanguages) list in settings. Note that sorting may not work as expected
 
 #### With Prettier
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
           "default": true,
           "description": "Sort Tailwind classes on save"
         },
+        "tailwindSorter.includeLanguages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Unsupported language identifiers to add to the list of supported languages. May not sort as expected. Example: plaintext"
+        },
         "tailwindSorter.customPrefixes": {
           "type": "array",
           "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 
 import getClassesMap from "./getClassesMap";
-import { languages } from "./lib/languages";
+import getLanguages from "./lib/languages";
 import sortTailwind from "./sortTailwind";
 
 // This method is called when your extension is activated
@@ -22,6 +22,8 @@ export async function sortOnCommand() {
   }
 
   const document = editor.document;
+  const languages = getLanguages();
+
   if (!languages.includes(document.languageId)) {
     vscode.window.showWarningMessage(
       `Tailwind Sorter: Language ${document.languageId} is not supported`
@@ -48,6 +50,7 @@ export async function sortOnCommand() {
 export function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
   const config = vscode.workspace.getConfiguration("tailwindSorter");
   const sortOnSave = config.get<boolean>("sortOnSave", true);
+  const languages = getLanguages();
 
   if (!sortOnSave || !languages.includes(event.document.languageId)) {
     return;

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -1,4 +1,6 @@
-export const languages = [
+import { workspace } from "vscode";
+
+const languages = [
   "html",
   "javascriptreact",
   "typescriptreact",
@@ -23,3 +25,16 @@ export const languages = [
   "razor",
   "aspnetcorerazor",
 ];
+
+/**
+ * Retrieves custom included languages from the workspace configuration
+ * and appends the list of supported language identifiers
+ *
+ * @returns An array containing languages to sort
+ */
+export default function getLanguages() {
+  const config = workspace.getConfiguration("tailwindSorter");
+  const includedLanguages = config.get("includeLanguages", []);
+
+  return [...languages, ...includedLanguages];
+}

--- a/src/test/_createConfigStub.ts
+++ b/src/test/_createConfigStub.ts
@@ -16,6 +16,7 @@ export default function createConfigStub(options = {}) {
     pseudoClassesOrder: { sortOrder: defaultPseudoSortOrder },
     customPrefixes: defaultCustomPrefixes,
     sortOnSave: defaultSortOnSave,
+    includeLanguages: [],
   };
 
   const config = { ...defaults, ...options };
@@ -35,6 +36,8 @@ export default function createConfigStub(options = {}) {
                 return config.pseudoClassesOrder;
               case "customPrefixes":
                 return config.customPrefixes;
+              case "includeLanguages":
+                return config.includeLanguages;
               case "sortOnSave":
                 return config.sortOnSave;
               default:

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -5,6 +5,7 @@ import * as sinon from "sinon";
 import { sortOnSave } from "../extension";
 import getClassesMap from "../getClassesMap";
 import createConfigStub from "./_createConfigStub";
+import getLanguages from "../lib/languages";
 
 suite("VS Code Configuration", () => {
   teardown(() => {
@@ -31,6 +32,15 @@ suite("VS Code Configuration", () => {
     });
 
     assert.deepStrictEqual(pseudoSortOrder, ["pseudo2", "pseudo1"]);
+  });
+
+  test("getLanguages includes custom languages from config", () => {
+    createConfigStub({
+      includeLanguages: ["potatoscript"],
+    });
+
+    const languages = getLanguages();
+    assert.ok(languages.includes("potatoscript"));
   });
 
   test("don't sort on command if language is not supported", async () => {
@@ -74,6 +84,46 @@ suite("VS Code Configuration", () => {
 
     const document = {
       languageId: "html",
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset),
+    } as vscode.TextDocument;
+
+    const replaceStub = sinon.stub();
+    const editBuilderMock = { replace: replaceStub };
+
+    const editSpy = sinon.spy((callback) => {
+      callback(editBuilderMock);
+      return Promise.resolve(true);
+    });
+
+    const activeTextEditor = {
+      document,
+      edit: editSpy,
+    } as unknown as vscode.TextEditor;
+    sinon.stub(vscode.window, "activeTextEditor").get(() => activeTextEditor);
+
+    await vscode.commands.executeCommand("tailwindSorter.sort");
+
+    sinon.assert.notCalled(showWarningMessageStub);
+    sinon.assert.called(editSpy);
+    sinon.assert.calledOnce(replaceStub);
+
+    const sortedTailwind = replaceStub.firstCall.args[1];
+    assert.strictEqual(sortedTailwind.includes("grid hover:grid"), true);
+  });
+
+  test("sort on command if language is included via config", async () => {
+    createConfigStub({
+      includeLanguages: ["potatoscript"],
+    });
+
+    const showWarningMessageStub = sinon.stub(
+      vscode.window,
+      "showWarningMessage"
+    );
+
+    const document = {
+      languageId: "potatoscript",
       getText: () => "<div class='hover:grid grid'></div>",
       positionAt: (offset: number) => new vscode.Position(0, offset),
     } as vscode.TextDocument;


### PR DESCRIPTION
- add `includeLanguage` to config settings 
- allow files with unsupported language identifiers to be sorted