### PR TITLE
More sort options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Custom sort order and categories can be configured in settings
    - Navigate to `File > Preferences > Settings`
 2. Search for "Tailwind Sorter" in the search bar at the top of the settings window
 3. Modify the settings according to your preferences:
-- [Category Order](vscode://settings/tailwindSorter.categoryOrder): The order categories will be sorted.
+- [Category Order](vscode://settings/tailwindSorter.categoryOrder): The order class categories will be sorted.
 - [Categories](vscode://settings/tailwindSorter.categories): Which style classes will belong to which category and in what order.
 - [Pseudo Classes Order](vscode://settings/tailwindSorter.pseudoClassesOrder): How pseudo-classes should be ordered.
+- [Section Order](vscode://settings/tailwindSorter.sectionOrder): The order class, pseudo class, and non-Tailwind class sections will be placed after sorting.
 - [Custom Prefixes](vscode://settings/tailwindSorter.customPrefixes): Prefixes that identify class strings other than the default `class=` and `className=`.
 - [Include Languages](vscode://settings/tailwindSorter.includeLanguages): Language identifiers to add to the list of supported languages. May not sort as expected.
 - [Sort on Save](vscode://settings/tailwindSorter.sortOnSave): Whether or not classes should be sorted on save.
-
 
 **The default category order is**: box model, grid, flex box, background, margins and padding, borders, width and height, typography, transformations, and other.
 
@@ -49,6 +49,12 @@ Custom sort order and categories can be configured in settings
       "inset-",
     ],
 ```
+
+
+**The default section order is**: classes (bg, text, etc.) then custom classes (non-Tailwind). By default, pseudo classes (hover:, sm:, etc.) are included in the classes section unless specified otherwise.
+
+- default: `bg-white, md:bg-black, text-pink-500, customCSSclass`
+- pseudo classes first: `md:bg-black, bg-white, text-pink-500, customCSSclass`
 
 **Custom Prefixes**: Tailwind Sorter checks for `class=` and `className=` as well as any custom prefixes defined in settings. Default custom prefixes include: `twMerge(`, `cva(`, `clsx(`, and `cn(`
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,22 @@
           "default": true,
           "description": "Sort Tailwind classes on save"
         },
+        "tailwindSorter.sectionOrder": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "classes",
+              "pseudoClasses",
+              "customClasses"
+            ]
+          },
+          "default": [
+            "classes",
+            "customClasses"
+          ],
+          "description": "Order that classes (text, bg), pseudo classes (hover:, md:), and custom classes (non-Tailwind) will be placed after sorting. By default pseudo classes are included in classes and any custom classes are placed at the end. \n\nExamples: \n - default: [\"classes\", \"customClasses\"] \n - pseudo classes split out [\"classes\", \"pseudoClasses\", \"customClasses\"] \n - custom classes to front [\"customClasses\", \"classes\"]"
+        },
         "tailwindSorter.includeLanguages": {
           "type": "array",
           "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,10 +31,15 @@ export async function sortOnCommand() {
     return;
   }
 
-  const { classesMap, pseudoSortOrder } = getClassesMap();
+  const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
 
   const text = document.getText();
-  const sortedTailwind = sortTailwind(text, classesMap, pseudoSortOrder);
+  const sortedTailwind = sortTailwind(
+    text,
+    classesMap,
+    pseudoSortOrder,
+    sectionOrder
+  );
 
   await editor.edit((editBuilder) => {
     editBuilder.replace(
@@ -56,10 +61,15 @@ export function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
     return;
   }
 
-  const { classesMap, pseudoSortOrder } = getClassesMap();
+  const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
 
   const text = event.document.getText();
-  const sortedTailwind = sortTailwind(text, classesMap, pseudoSortOrder);
+  const sortedTailwind = sortTailwind(
+    text,
+    classesMap,
+    pseudoSortOrder,
+    sectionOrder
+  );
 
   // onWillSave + waitUntil prevents looping
   event.waitUntil(

--- a/src/getClassesMap.ts
+++ b/src/getClassesMap.ts
@@ -3,6 +3,7 @@ import {
   defaultCategories,
   defaultSortOrder,
   defaultPseudoSortOrder,
+  defaultSectionOrder
 } from "./lib/defaultConfig";
 
 /**
@@ -81,6 +82,14 @@ export default function getClassesMap() {
     pseudoSortOrder = defaultPseudoSortOrder;
   }
 
+  const sectionOrderConfig: string[] = config.get("sectionOrder",  defaultSectionOrder);
+
+  const sectionOrder: string[] =
+    sectionOrderConfig && sectionOrderConfig.includes("classes") && sectionOrderConfig.includes("customClasses")
+      ? sectionOrderConfig
+      : defaultSectionOrder;
+
+
   let classesMap: { [property: string]: number } = {};
 
   let index = 0;
@@ -90,5 +99,5 @@ export default function getClassesMap() {
     });
   });
 
-  return { classesMap, pseudoSortOrder };
+  return { classesMap, pseudoSortOrder, sectionOrder };
 }

--- a/src/lib/defaultConfig.ts
+++ b/src/lib/defaultConfig.ts
@@ -550,3 +550,4 @@ export const defaultPseudoSortOrder =
 
 export const defaultCustomPrefixes = ["twMerge(", "clsx(", "cva(", "cn("];
 export const defaultSortOnSave = true;
+export const defaultSectionOrder = ["classes", "customClasses"];

--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -3,7 +3,7 @@ import {
   createRegex,
   colonRegex,
   dynamicSyntaxMarkers,
-  parenthesis,
+  parenthesis
 } from "./lib/regex";
 
 /**
@@ -17,11 +17,18 @@ import {
 export default function sortTailwind(
   text: string,
   sortConfig: { [key: string]: number },
-  pseudoClasses: string[]
+  pseudoClasses: string[],
+  sectionOrder: string[]
 ) {
   const applyRegex = createApplyRegex();
   text = text.replace(applyRegex, (match, classesGroup) => {
-    return sortFoundTailwind(match, classesGroup, sortConfig, pseudoClasses);
+    return sortFoundTailwind(
+      match,
+      classesGroup,
+      sortConfig,
+      pseudoClasses,
+      sectionOrder
+    );
   });
 
   const regex = createRegex();
@@ -38,7 +45,13 @@ export default function sortTailwind(
       const quotesGroup =
         singleQuotesGroup || doubleQuotesGroup || backtickQuotesGroup;
 
-      return sortFoundTailwind(match, quotesGroup, sortConfig, pseudoClasses);
+      return sortFoundTailwind(
+        match,
+        quotesGroup,
+        sortConfig,
+        pseudoClasses,
+        sectionOrder
+      );
     }
   );
 
@@ -52,12 +65,14 @@ export default function sortTailwind(
  * @param classesStr - The tailwind classes. ex: bg-blue-500 text-white
  * @param sortConfig - The sort config object that maps style classes to their sort order index.
  * @param pseudoClasses - An array of pseudo classes to sort by.
+ * @param sectionOrder - The order of classes, pseudo classes, and custom classes
  */
 function sortFoundTailwind(
   match: string,
   classesStr: string,
   sortConfig: { [key: string]: number },
-  pseudoClasses: string[]
+  pseudoClasses: string[],
+  sectionOrder: string[]
 ) {
   if (!classesStr || !classesStr.includes(" ")) {
     return match;
@@ -79,71 +94,71 @@ function sortFoundTailwind(
     return match;
   }
 
-  const { unsortedClasses, ignoredClasses } = classes.reduce(
-    (acc, className) => {
-      const match = findLongestMatch(className, sortConfig);
+  const base = sectionOrder.indexOf("classes") * 1000;
+  const pseudoIndex = sectionOrder.indexOf("pseudoClasses");
+  const bases = {
+    class: base,
+    pseudo: pseudoIndex !== -1 ? pseudoIndex * 1000 : base,
+    custom: sectionOrder.indexOf("customClasses") * 1000
+  };
 
-      match
-        ? acc.unsortedClasses.push(className)
-        : acc.ignoredClasses.push(className);
+  const sortedClasses = classes.sort((aClass: string, bClass: string) => {
+    const [aIndex, aIsPseudo] = findIndex(aClass, bases, sortConfig, classes);
+    const [bIndex, bIsPseudo] = findIndex(bClass, bases, sortConfig, classes);
 
-      return acc;
-    },
-    { unsortedClasses: [] as string[], ignoredClasses: [] as string[] }
-  );
-
-  const sortedClasses = unsortedClasses.sort(
-    (aClass: string, bClass: string) => {
-      const a = findLongestMatch(aClass, sortConfig);
-      const b = findLongestMatch(bClass, sortConfig);
-
-      const aBaseClass = aClass.split(colonRegex).pop() || aClass;
-      const bBaseClass = bClass.split(colonRegex).pop() || bClass;
-
-      const aIsPseudo = aBaseClass !== aClass;
-      const bIsPseudo = bBaseClass !== bClass;
-
-      const aIsNotVariant = aBaseClass.includes("not-");
-      const bIsNotVariant = bBaseClass.includes("not-");
-
-      const aOffset = aIsPseudo
-        ? aIsNotVariant
-          ? 0.75
-          : 0.5
-        : aIsNotVariant
-        ? 0.25
-        : 0;
-
-      const bOffset = bIsPseudo
-        ? bIsNotVariant
-          ? 0.75
-          : 0.5
-        : bIsNotVariant
-        ? 0.25
-        : 0;
-
-      // assign each class its sortConfig index and add offset
-      // 0.25: not- class, 0.5: pseudo class, 0.75: not- pseudo class
-      const aIndex = sortConfig[a] + aOffset;
-      const bIndex = sortConfig[b] + bOffset;
-
-      if (aIndex === bIndex) {
-        if (aIsPseudo && bIsPseudo) {
-          // sort pseudo classes by config order
-          return comparePseudoClasses(aClass, bClass, pseudoClasses);
-        }
-
-        // otherwise sort alphabetically
-        return aClass.localeCompare(bClass);
-      }
-
+    if (aIndex !== bIndex) {
       return aIndex - bIndex;
     }
-  );
 
-  const sortedClassesStr = [...sortedClasses, ...ignoredClasses].join(" ");
+    if (aIsPseudo && bIsPseudo) {
+      // sort pseudo classes by config order
+      return comparePseudoClasses(aClass, bClass, pseudoClasses);
+    }
 
-  return match.replace(classesStr, sortedClassesStr);
+    // otherwise sort alphabetically
+    return aClass.localeCompare(bClass);
+  });
+
+  return match.replace(classesStr, sortedClasses.join(" "));
+}
+
+/**
+ * Finds sort index of a given class
+ *
+ * @param aClass - The style class to find an index for. (overflow-x-12)
+ * @param bases - The map of base offset numbers for classes, pseudo classes, custom classes
+ * @param sortConfig - The sort config object.
+ * @param classes - The array of classes being sorted.
+ * @returns sort index, if class is a pseudo class (hover:)
+ */
+function findIndex(
+  aClass: string,
+  bases: { [key: string]: number },
+  sortConfig: { [key: string]: number },
+  classes: string[]
+): [number, boolean] {
+  const match = findLongestMatch(aClass, sortConfig);
+
+  if (!match) {
+    const customIndex = bases.custom + classes.indexOf(aClass);
+    return [customIndex, false];
+  }
+
+  const baseClass = aClass?.split(colonRegex).pop() || aClass;
+  const isPseudo = baseClass !== aClass;
+  const isNotVariant = baseClass.includes("not-");
+
+  const offset = isPseudo
+    ? isNotVariant
+      ? bases.pseudo + 0.75
+      : bases.pseudo + 0.5
+    : isNotVariant
+      ? bases.class + 0.25
+      : bases.class + 0;
+
+  // assign each class its sortConfig index and add offset
+  // 0.25: not- class, 0.5: pseudo class, 0.75: not- pseudo class
+  return [sortConfig[match] + offset, isPseudo];
 }
 
 /**

--- a/src/test/_createConfigStub.ts
+++ b/src/test/_createConfigStub.ts
@@ -7,6 +7,7 @@ import {
   defaultPseudoSortOrder,
   defaultCustomPrefixes,
   defaultSortOnSave,
+  defaultSectionOrder
 } from "../lib/defaultConfig";
 
 export default function createConfigStub(options = {}) {
@@ -16,6 +17,7 @@ export default function createConfigStub(options = {}) {
     pseudoClassesOrder: { sortOrder: defaultPseudoSortOrder },
     customPrefixes: defaultCustomPrefixes,
     sortOnSave: defaultSortOnSave,
+    sectionOrder: defaultSectionOrder,
     includeLanguages: [],
   };
 
@@ -40,6 +42,8 @@ export default function createConfigStub(options = {}) {
                 return config.includeLanguages;
               case "sortOnSave":
                 return config.sortOnSave;
+              case "sectionOrder":
+                return config.sectionOrder;
               default:
                 return undefined;
             }

--- a/src/test/_defaultClassMap.ts
+++ b/src/test/_defaultClassMap.ts
@@ -3,6 +3,7 @@ import {
   defaultCategories,
   defaultSortOrder,
   defaultPseudoSortOrder,
+  defaultSectionOrder
 } from "../lib/defaultConfig";
 
 export function defaultClassesMap() {
@@ -15,5 +16,9 @@ export function defaultClassesMap() {
     });
   });
 
-  return { classesMap, pseudoSortOrder: defaultPseudoSortOrder };
+  return {
+    classesMap,
+    pseudoSortOrder: defaultPseudoSortOrder,
+    sectionOrder: defaultSectionOrder
+  };
 }

--- a/src/test/_sortHelper.ts
+++ b/src/test/_sortHelper.ts
@@ -1,0 +1,9 @@
+import sortTailwind from "../sortTailwind";
+import { defaultClassesMap } from "./_defaultClassMap";
+
+const sortHelper = (unsortedStr: string) => {
+    const { classesMap, pseudoSortOrder, sectionOrder } = defaultClassesMap();
+    return sortTailwind(unsortedStr, classesMap, pseudoSortOrder, sectionOrder);
+};
+
+export default sortHelper;

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -20,9 +20,10 @@ suite("VS Code Configuration", () => {
       },
       categoryOrder: { sortOrder: ["category1", "category2"] },
       pseudoClassesOrder: { sortOrder: ["pseudo2", "pseudo1"] },
+      sectionOrder: ["customClasses", "classes", "pseudoClasses"],
     });
 
-    const { classesMap, pseudoSortOrder } = getClassesMap();
+    const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
 
     assert.deepStrictEqual(classesMap, {
       class1: 0,
@@ -32,6 +33,11 @@ suite("VS Code Configuration", () => {
     });
 
     assert.deepStrictEqual(pseudoSortOrder, ["pseudo2", "pseudo1"]);
+    assert.deepStrictEqual(sectionOrder, [
+      "customClasses",
+      "classes",
+      "pseudoClasses",
+    ]);
   });
 
   test("getLanguages includes custom languages from config", () => {

--- a/src/test/regression.test.ts
+++ b/src/test/regression.test.ts
@@ -1,15 +1,17 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
+import { restore } from "sinon";
 
-import sortTailwind from "../sortTailwind";
 import createConfigStub from "./_createConfigStub";
-import { defaultClassesMap } from "./_defaultClassMap";
+import sortHelper from "./_sortHelper";
 
 const FIXTURES_DIR = path.join(process.cwd(), "src/test/fixtures");
 
 suite("Regression tests", () => {
-  const { classesMap, pseudoSortOrder } = defaultClassesMap();
+  teardown(() => {
+    restore();
+  });
 
   const languages = fs.readdirSync(FIXTURES_DIR);
 
@@ -36,7 +38,7 @@ suite("Regression tests", () => {
       const input = fs.readFileSync(fixturePath, "utf8");
       const expectedOutput = fs.readFileSync(expectedPath, "utf8");
 
-      const actualOutput = sortTailwind(input, classesMap, pseudoSortOrder);
+      const actualOutput = sortHelper(input);
 
       fs.writeFileSync(sortedPath, actualOutput, "utf8");
 

--- a/src/test/section-order.test.ts
+++ b/src/test/section-order.test.ts
@@ -1,0 +1,104 @@
+import * as assert from "assert";
+
+import sortTailwind from "../sortTailwind";
+import { defaultClassesMap } from "./_defaultClassMap";
+
+suite("Section Order", () => {
+  const { classesMap, pseudoSortOrder } = defaultClassesMap();
+
+  test('default ["classes", "customClasses"]', () => {
+    const unsortedString = `<div class="hover:bg-blue-500 potato flex bg-black custom text-white lg:text-gray-100">`;
+    const sortedString = `<div class="flex bg-black hover:bg-blue-500 text-white lg:text-gray-100 potato custom">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "classes",
+        "customClasses"
+      ]),
+      sortedString
+    );
+  });
+
+  test('["customClasses", "classes"]', () => {
+    const unsortedString = `<div class="hover:bg-blue-500 flex custom bg-black text-white potato lg:text-gray-100">`;
+    const sortedString = `<div class="custom potato flex bg-black hover:bg-blue-500 text-white lg:text-gray-100">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "customClasses",
+        "classes"
+      ]),
+      sortedString
+    );
+  });
+
+  test('["classes", "pseudoClasses"]', () => {
+    const unsortedString = `<div class="flex flex-col md:flex-row justify-between gap-4 p-4 md:p-8 bg-background">`;
+    const sortedString = `<div class="flex flex-col justify-between gap-4 bg-background p-4 md:flex-row md:p-8">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "classes",
+        "pseudoClasses",
+        "customClasses"
+      ]),
+      sortedString
+    );
+  });
+
+  test('["classes", "pseudoClasses", "customClasses"]', () => {
+    const unsortedString = `<div class="hover:bg-blue-500 flex custom bg-black text-white potato lg:text-gray-100">`;
+    const sortedString = `<div class="flex bg-black text-white hover:bg-blue-500 lg:text-gray-100 custom potato">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "classes",
+        "pseudoClasses",
+        "customClasses"
+      ]),
+      sortedString
+    );
+  });
+
+  test('["pseudoClasses", "classes", "customClasses"]', () => {
+    const unsortedString = `<div class="hover:bg-blue-500 flex custom bg-black frog potato text-white lg:text-gray-100">`;
+    const sortedString = `<div class="hover:bg-blue-500 lg:text-gray-100 flex bg-black text-white custom frog potato">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "pseudoClasses",
+        "classes",
+        "customClasses"
+      ]),
+      sortedString
+    );
+  });
+
+  test('["customClasses", "classes", "pseudoClasses"]', () => {
+    const unsortedString = `<div class="hover:bg-blue-500 flex frog bg-black text-white lg:text-gray-100 custom">`;
+    const sortedString = `<div class="frog custom flex bg-black text-white hover:bg-blue-500 lg:text-gray-100">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "customClasses",
+        "classes",
+        "pseudoClasses"
+      ]),
+      sortedString
+    );
+  });
+
+  test('["classes", "customClasses", "pseudoClasses"]', () => {
+    const unsortedString = `<div class="hover:bg-blue-500 flex bg-black text-white potato lg:text-gray-100 custom">`;
+    const sortedString = `<div class="flex bg-black text-white potato custom hover:bg-blue-500 lg:text-gray-100">`;
+
+    assert.strictEqual(
+      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
+        "classes",
+        "customClasses",
+        "pseudoClasses"
+      ]),
+      sortedString
+    );
+  });
+});

--- a/src/test/sorting-ignore.test.ts
+++ b/src/test/sorting-ignore.test.ts
@@ -1,13 +1,10 @@
 import * as assert from "assert";
 import { restore } from "sinon";
 
-import sortTailwind from "../sortTailwind";
-import { defaultClassesMap } from "./_defaultClassMap";
 import createConfigStub from "./_createConfigStub";
+import sortHelper from "./_sortHelper";
 
 suite("Ignore sorting", () => {
-  const { classesMap, pseudoSortOrder } = defaultClassesMap();
-
   teardown(() => {
     restore();
   });
@@ -17,7 +14,7 @@ suite("Ignore sorting", () => {
       "<div class={`button ${isActive ? 'button-active' : 'button-inactive'}`}";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -27,7 +24,7 @@ suite("Ignore sorting", () => {
       '<div class={`button ${isActive ? "button-active" : "button-inactive"}`}';
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -37,7 +34,7 @@ suite("Ignore sorting", () => {
       "<div className={`flex items-center gap-1.5 rounded-lg border-2 px-3 py-1.5 ${buttonClasses.DEFAULT}`}>";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -46,7 +43,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div :class="{ 'text-white': isActive, 'bg-blue-500': isActive }"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -55,7 +52,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div :class="[{ 'bg-red-500': !isActive, 'bg-blue-500': isActive }, 'text-white']`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -64,7 +61,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<button class="text-white #{dynamic_class} bg-blue-500">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -73,7 +70,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<button class="<%= is_active ? 'text-white bg-green-500' : 'text-white bg-gray-500' %> text-white bg-blue-500 rounded">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -84,7 +81,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<%= link_to "Home", root_path, class: "nav-link #{'text-pink-500 bg-white' if current_page?(root_path)}" %>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -95,7 +92,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<%= link_to "Dashboard", dashboard_path, class: ["text-pink-500 bg-white", current_user.admin? ? "bg-red-500 text-white" : "bg-blue-500 text-white"] %>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -106,7 +103,7 @@ suite("Ignore sorting", () => {
 </div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -120,7 +117,7 @@ suite("Ignore sorting", () => {
 </p>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -135,7 +132,7 @@ suite("Ignore sorting", () => {
 </ul>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -144,7 +141,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div [class.text-white]="isPrimary" [class.bg-blue-500]="isPrimary"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -153,7 +150,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class="'bg-' + (isActive ? 'green' : 'red') + '-500'"></div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -162,7 +159,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class="bg-blue {{ widget.size }}  case-video-container {{ widget.marginTop }} {{ widget.marginBottom }} waiting appear appear-video-playing text-lg"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -171,7 +168,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div data-htmx-class="bg-blue-500:text-white:bg-gray-300"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -185,7 +182,7 @@ suite("Ignore sorting", () => {
     }"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -201,7 +198,7 @@ suite("Ignore sorting", () => {
       "}";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -213,7 +210,7 @@ suite("Ignore sorting", () => {
 </div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -229,7 +226,7 @@ suite("Ignore sorting", () => {
 <div class="<%= classes %>"></div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -238,7 +235,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<%- include('components/button', { className: 'bg-blue-500 text-white' }) %>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -247,7 +244,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class="<%- someClass %> px-4 py-2 rounded"></div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -256,7 +253,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div x-data="{ isPrimary: true, isActive: true }"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -265,7 +262,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div x-bind:class="basketItem.quantity  === 1 ? 'bg-slate-200' : ''"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -274,7 +271,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class:isActive="bg-blue-400 text-white bg-blue-500"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -283,7 +280,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class:isActive={isActive ? "bg-blue-400 text-white bg-blue-500" : "text-gray-500 bg-white"}>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -292,7 +289,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class:isActive={isActive} class="bg-{color}-400 text-white">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -301,7 +298,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class:isActive={isActive} class="bg-blue-400 text-white {isDisabled ? 'opacity-50' : ''}">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -310,7 +307,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class="justify-center flex {{ extra_classes }}">Hello</div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -325,7 +322,7 @@ suite("Ignore sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -334,7 +331,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<button class="text-pink-500 bg-white mt-5 px-4 py-2 <%= @button_color %> text-white rounded hover:<%= @button_hover_color %>"></button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -343,7 +340,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<span class={if @counter > 5, do: "text-2xl text-red-500", else: "text-2xl text-gray-500"} id="counter">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -353,7 +350,7 @@ suite("Ignore sorting", () => {
       "<button {...props} className={twMerge(BTN_PRIMARY_CLASSNAMES, props.className)} />";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -370,7 +367,7 @@ suite("Ignore sorting", () => {
         >`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -379,7 +376,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `clsx({ foo:true }, { bar:false }, null, { '--foobar':'hello' })`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -396,7 +393,7 @@ suite("Ignore sorting", () => {
     })`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -412,7 +409,7 @@ suite("Ignore sorting", () => {
 }) %}`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -421,7 +418,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `cva({ 'bg-blue-700 text-gray-100': isHovering })`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -430,7 +427,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<style jsx>{\`.btn { @apply bg-\${color} text-white; }\`}</style>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -439,7 +436,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<style>.btn { @apply bg-{{ color }} text-{{ textColor }}; }</style>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -448,7 +445,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<style>.btn { @apply bg-<%= @color %> text-white; }</style>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -457,7 +454,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `.btn { @apply bg-#{$base-color}-#{$shade + 100} text-white; }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -466,7 +463,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<style>.btn { @apply bg-{color} text-white; }</style>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -475,7 +472,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `.btn { @apply bg-var(--color) text-white; }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -484,7 +481,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `.btn { @apply bg-#{map-get($theme, primary)} text-#{map-get($theme, text)}; }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -496,7 +493,7 @@ suite("Ignore sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -506,7 +503,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class="[mask-type:luminance] hover:[mask-type:alpha]">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -519,7 +516,7 @@ suite("Ignore sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -534,7 +531,7 @@ suite("Ignore sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -551,7 +548,7 @@ suite("Ignore sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -560,7 +557,7 @@ suite("Ignore sorting", () => {
     const unsortedString = "<div class={`bg-${color}-500`}>Hello, world!</div>";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -569,7 +566,7 @@ suite("Ignore sorting", () => {
     const unsortedString = `<div class="<?php echo "bg-$color-500"; ?>">Hello, world!</div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -585,7 +582,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
 </div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -597,7 +594,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
 </button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -612,7 +609,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
       </button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -621,7 +618,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `<div class="flex-col @string.Join(" ", classes) flex">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -630,7 +627,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `<div class="p-4 @(isActive ? "bg-green-200 flex" : "bg-gray-200") flex-col">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -639,7 +636,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `@Html.Raw($"<div class=\"p-4 bg-{Model.Color}-500\">Text</div>")`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -648,7 +645,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `<div class="bg-{% color %}-500">Hello, world!</div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -657,7 +654,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `<div class="bg-{{ color }}-500">Hello, world!</div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -666,7 +663,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `<div class="<%= "bg-#{color}-500" %>">Hello, world!</div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });
@@ -675,7 +672,7 @@ $bgClass = $isActive ? 'bg-green-500' : 'bg-red-500';
     const unsortedString = `<div class="<%= $"bg-{color}-500" %>">Hello, world!</div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       unsortedString
     );
   });

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -1,16 +1,10 @@
 import * as assert from "assert";
 import { restore } from "sinon";
-import * as vscode from "vscode";
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import sortTailwind from "../sortTailwind";
-import { defaultClassesMap } from "./_defaultClassMap";
 import createConfigStub from "./_createConfigStub";
+import sortHelper from "./_sortHelper";
 
 suite("Sorting", () => {
-  const { classesMap, pseudoSortOrder } = defaultClassesMap();
-
   teardown(() => {
     restore();
   });
@@ -20,7 +14,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="font-semibold after:content-[''] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[''] items-center" blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -30,7 +24,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className='font-semibold after:content-[""] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[""] items-center' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -41,7 +35,7 @@ suite("Sorting", () => {
     const sortedString = `<div class="z-50 absolute before:absolute sticky flex flex-col justify-between gap-6 md:grid grid-cols-3 bg-[radial-gradient(circle_at_top_left,#1e3a8a,#9333ea)] sm:bg-yellow-400 sm:hover:bg-[url('/noise.png')] lg:dark:bg-gradient-to-tr bg-cover bg-no-repeat bg-center bg-fixed before:opacity-50 group-hover:opacity-90 hover:shadow-2xl md:backdrop-blur-xl dark:hover:brightness-75 -mt-2 lg:mt-10 p-10 md:py-12 lg:pl-8 border-4 rounded-xl focus-within:ring-4 peer-invalid:ring-red-500 w-[calc(100%-4rem)] sm:w-1/2 md:max-w-3xl h-screen min-h-[50vh] overflow-hidden font-black text-blue-500 sm:dark:text-green-400 hover:text-white sm:text-lg text-3xl text-center underline text-balance after:content-[''] hover:focus:rotate-3 sm:hover:scale-105 hover:skew-x-6 translate-x-1/2 sm:even:translate-x-4 sm:peer-checked:translate-y-3 sm:translate-x-2 select-none hover:contrast-125" blah blah>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -51,7 +45,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className='lg:self-start -ml-5 relative justify-center custom self-center lg:ml-0 shape-wrapper w-[375px] lg:w-[568px] h-[375px] lg:h-[568px] flex'`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -61,7 +55,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="flex-col carrot flex-1 banana flex apple" blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -71,7 +65,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="banana carrot-1 flex-col carrot-1 hover:carrot flex-1 apple flex" blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -82,7 +76,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="foo bar tw-text-2xl tw:px-4"><div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -92,7 +86,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className='flex grayscale bg-white bg-inverted/25 bg-blue-500 invert' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -102,7 +96,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className='flex' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -112,7 +106,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className=''></div><div className='flex-col flex' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -122,7 +116,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className="flex-col flex"></div><div className='flex-col flex' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -132,7 +126,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className="top-0 left-10 left-0 lg:static fixed flex justify-center left-0"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -142,7 +136,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className="top-0 hover:lg:left-10 hover:lg:left-0 lg:static fixed flex justify-center hover:lg:left-0"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -152,7 +146,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="focus-within:ring-blue-200 group-hover:text-blue-500 focus-within:ring" blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -162,7 +156,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="hover:not-xl:bg-indigo-700 bg-indigo-600 hover:not-focus:bg-indigo-700 hover:not-lg:bg-indigo-700"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -173,7 +167,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="supports-backdrop-filter:bg-black/25 supports-[display:flex]:flex supports-[display:grid]:grid">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -183,7 +177,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="[&>*:not(:first-child)]:mt-2 [&:nth-child(3)]:bg-blue-500">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -193,7 +187,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="max-6xl:not-disabled:bg-green-500 5xl:not-disabled:bg-blue-500 4xl:not-disabled:bg-pink-400">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -203,7 +197,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="md:visited:bg-red-600 lg:focus-within:bg-green-500 sm:hover:bg-blue-500 md:group-hover:bg-red-500">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -213,7 +207,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="group-hover:bg-blue-500 focus-within:bg-green-500 hover:bg-pink-500"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -223,7 +217,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="peer-hover:bg-yellow-500 2xl:hover:bg-blue-400 group-hover:bg-pink-500 hover:bg-blue-500">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -233,7 +227,7 @@ suite("Sorting", () => {
     const unsortedString = `<a class="group-hover/item:visible invisible group/edit" href="tel:{person.phone}">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -243,7 +237,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="hover:bg-red-500 aria-[expanded=true]:bg-green-500 data-[open=true]:bg-blue-500">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -253,7 +247,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="@sm:@max-lg:flex-col @sm:@max-md:flex-col flex"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -263,7 +257,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="@lg:flex group-hover:text-blue-500 flex @md:flex @sm:flex text-black"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -273,7 +267,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="min-[320px]:text-center max-[600px]:bg-sky-300 @container">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -283,7 +277,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className='h-[calc(100%-1rem)] w-[100px] bg-[#1a1a1a]' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -293,7 +287,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="before:content-[attr(data:time)] content-['Time:_12:30_PM']">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -303,7 +297,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="w-[calc(100%-theme('spacing.2'))] grid-cols-[minmax(0,_1fr)_50px]">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -313,7 +307,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="-skew-y-3 -translate-y-full -m-2 -inset-x-4">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -323,7 +317,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="translate-x-1/2 w-2/3 gap-x-1/2 grid-cols-[1fr,2fr] grid">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -333,7 +327,7 @@ suite("Sorting", () => {
     const unsortedString = `class="text-black bg-[url('image.jpg')]"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -343,7 +337,7 @@ suite("Sorting", () => {
     const unsortedString = `<div className='-mb-5 z-10 -mt-5' blah blah`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -353,7 +347,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="text-black bg-[var(--my-color)]"></div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -363,7 +357,7 @@ suite("Sorting", () => {
     const unsortedString = `<div data-current class="data-current:opacity-100 bg-black opacity-75">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -373,7 +367,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="not-hover:opacity-75 hover:opacity-100 bg-black">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -383,7 +377,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="banana tw-not-hover:opacity-75 apple tw-hover:opacity-100 tw:bg-black">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -393,7 +387,7 @@ suite("Sorting", () => {
     const unsortedString = `<div class="w-md w-xs w-2xl w-1/12 hover:w-md">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -403,7 +397,7 @@ suite("Sorting", () => {
     const unsortedString = `<Component className="text-yellow-800 bg-yellow-100" />`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -417,7 +411,7 @@ This is a **bold** paragraph.
 <Component className="flex-col flex">mdx</Component>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -435,7 +429,7 @@ This is a **bold** paragraph.
 `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -449,7 +443,7 @@ This is a **bold** paragraph.
       <% } %>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -459,7 +453,7 @@ This is a **bold** paragraph.
     const unsortedString = `<div class="text-white bg-blue-500"`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -489,7 +483,7 @@ This is a **bold** paragraph.
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -499,7 +493,7 @@ This is a **bold** paragraph.
     const unsortedString = `<span class="text-white bg-blue-500" id="counter"><%= @counter %></span>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -509,7 +503,7 @@ This is a **bold** paragraph.
     const unsortedString = `<button class="flex-row flex" on:click=on_click>"Welcome to Leptos!"</button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -519,7 +513,7 @@ This is a **bold** paragraph.
     const unsortedString = `<button class="text-white bg-blue-500" onclick={ctx.link().callback(|_| Msg::Random)}>{ "Random" }</button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -529,7 +523,7 @@ This is a **bold** paragraph.
     const unsortedString = `<button class="text-white bg-blue-500" onclick="<?php echo $link; ?>"><?php echo $label; ?></button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -543,7 +537,7 @@ This is a **bold** paragraph.
     </button>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -557,7 +551,7 @@ This is a **bold** paragraph.
     {% endblock %}`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -572,7 +566,7 @@ This is a **bold** paragraph.
   {% endblock %}`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -588,7 +582,7 @@ This is a **bold** paragraph.
 </div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -606,7 +600,7 @@ This is a **bold** paragraph.
 }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -623,7 +617,7 @@ This is a **bold** paragraph.
       @endsection`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -633,7 +627,7 @@ This is a **bold** paragraph.
     const unsortedString = `<div class:isActive={isActive && !isDisabled} class="bg-blue-400 text-white bg-blue-500">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -645,7 +639,7 @@ This is a **bold** paragraph.
     const unsortedString = `<%= f.label :name, class: "bg-blue-500 text-white bg-blue-400" %>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -657,7 +651,7 @@ This is a **bold** paragraph.
     const unsortedString = `<%= form_with(model: @user, class: 'text-white bg-pink-500') do |f| %>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -669,7 +663,7 @@ This is a **bold** paragraph.
     const unsortedString = `form_with model: @user, class: 'text-white bg-pink-500' do |f|`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -681,7 +675,7 @@ This is a **bold** paragraph.
     const unsortedString = `tag.svg(class: "size-full flex-col -rotate-90 flex", viewBox: "0 0 36 36", xmlns: "http://www.w3.org/2000/svg") do`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -693,7 +687,7 @@ This is a **bold** paragraph.
     const unsortedString = `form_with(model: @user, class: 'text-white bg-pink-500') do |f|`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -705,7 +699,7 @@ This is a **bold** paragraph.
     const unsortedString = `has_dom_class -> { 'text-white bg-pink-500' }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -727,7 +721,7 @@ This is a **bold** paragraph.
 </ul>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -737,7 +731,7 @@ This is a **bold** paragraph.
     const unsortedString = `<div {% if block.settings.highlight %}class="bg-yellow-100 flex-col flex"{% endif %}>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -755,7 +749,7 @@ This is a **bold** paragraph.
       "    }";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -768,7 +762,7 @@ This is a **bold** paragraph.
       "twMerge('hover:bg-dark-red bg-red', 'p-3 bg-[#B91C1C]')";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -779,7 +773,7 @@ This is a **bold** paragraph.
     const unsortedString = "twMerge(`lg:grid-cols-[1fr,auto] grid-cols-2`)";
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -789,7 +783,7 @@ This is a **bold** paragraph.
     const unsortedString = `<aside className={twMerge(' p-4     flex    ')}>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -799,7 +793,7 @@ This is a **bold** paragraph.
     const unsortedString = `<aside className={ twMerge(' p-4     flex    ')}>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -817,7 +811,7 @@ This is a **bold** paragraph.
     };`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -827,7 +821,7 @@ This is a **bold** paragraph.
     const unsortedString = `<div className={cn("relative overflow-auto w-full", wrapperClassName)}>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -837,7 +831,7 @@ This is a **bold** paragraph.
     const unsortedString = `  return <tfoot className={cn("bg-muted/50 border-t last:[&>tr]:border-b-0", className)} {...rest} />;`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -859,7 +853,7 @@ className
 />]`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -885,7 +879,7 @@ className
       ></span>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -898,7 +892,7 @@ className
     const unsortedString = `clsx('text-base bg-blue-500', { 'bg-blue-700 text-gray-100': isHovering })`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -908,7 +902,7 @@ className
     const unsortedString = `clsx('text-base           bg-blue-500     ')`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -918,7 +912,7 @@ className
     const unsortedString = `clsx('text-black bg-pink-500', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya')`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -933,7 +927,7 @@ className
     const unsortedString = `cva('text-white bg-blue-500', { 'bg-blue-700 text-gray-100': isHovering })`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -959,7 +953,7 @@ className
     })`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -969,15 +963,13 @@ className
     const unsortedString = `<div class="_shadow-2xl justify-center custom_flex gap-6 _hover:border-yellow-400 bg-white _flex-col p-8 border flex rounded-4xl w-lg">`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
 });
 
 suite("@apply Sorting", () => {
-  const { classesMap, pseudoSortOrder } = defaultClassesMap();
-
   test("css", () => {
     const unsortedString = `
     .btn {
@@ -993,7 +985,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1011,7 +1003,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1041,7 +1033,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1069,7 +1061,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1091,7 +1083,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1121,7 +1113,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1151,7 +1143,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1185,7 +1177,7 @@ suite("@apply Sorting", () => {
     `;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1201,7 +1193,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1217,7 +1209,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1235,7 +1227,7 @@ suite("@apply Sorting", () => {
       </style>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1259,7 +1251,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1307,7 +1299,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1371,7 +1363,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1401,7 +1393,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1435,7 +1427,7 @@ suite("@apply Sorting", () => {
     }`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });
@@ -1457,7 +1449,7 @@ suite("@apply Sorting", () => {
     </div>`;
 
     assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder),
+      sortHelper(unsortedString),
       sortedString
     );
   });


### PR DESCRIPTION
move out testing sort logic to a helper
add section placement order config, which will allow:
- pseudo classes to be sorted separately from classes
- custom (non tailwind) classes to be sorted to start or end