### PR TITLE
Exclude file extensions and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Custom sort order and categories can be configured in settings
 - [Section Order](vscode://settings/tailwindSorter.sectionOrder): The order class, pseudo class, and non-Tailwind class sections will be placed after sorting.
 - [Custom Prefixes](vscode://settings/tailwindSorter.customPrefixes): Prefixes that identify class strings other than the default `class=` and `className=`.
 - [Include Languages](vscode://settings/tailwindSorter.includeLanguages): Language identifiers to add to the list of supported languages. May not sort as expected.
+- [Exclude Languages](vscode://settings/tailwindSorter.excludeLanguages): Language identifiers to remove from the list of supported languages. Files with these language identifiers will not be sorted.
 - [Sort on Save](vscode://settings/tailwindSorter.sortOnSave): Whether or not classes should be sorted on save.
 
 **The default category order is**: box model, grid, flex box, background, margins and padding, borders, width and height, typography, transformations, and other.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Custom sort order and categories can be configured in settings
 - [Custom Prefixes](vscode://settings/tailwindSorter.customPrefixes): Prefixes that identify class strings other than the default `class=` and `className=`.
 - [Include Languages](vscode://settings/tailwindSorter.includeLanguages): Language identifiers to add to the list of supported languages. May not sort as expected.
 - [Exclude Languages](vscode://settings/tailwindSorter.excludeLanguages): Language identifiers to remove from the list of supported languages. Files with these language identifiers will not be sorted.
+- [Ignore Paths](vscode://settings/tailwindSorter.ignorePaths): File paths to ignore. File names matching these glob patterns will not be sorted.
 - [Sort on Save](vscode://settings/tailwindSorter.sortOnSave): Whether or not classes should be sorted on save.
 
 **The default category order is**: box model, grid, flex box, background, margins and padding, borders, width and height, typography, transformations, and other.

--- a/package.json
+++ b/package.json
@@ -59,9 +59,19 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^[^.]"
           },
           "description": "Unsupported language identifiers to add to the list of supported languages. May not sort as expected. Example: plaintext"
+        },
+        "tailwindSorter.excludeLanguages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^.]"
+          },
+          "description": "Language identifiers to remove from the list of supported languages. Files with these language identifiers will not be sorted. Example: html"
         },
         "tailwindSorter.customPrefixes": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,14 @@
           },
           "description": "Language identifiers to remove from the list of supported languages. Files with these language identifiers will not be sorted. Example: html"
         },
+        "tailwindSorter.ignorePaths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "File paths to ignore. File names matching these glob patterns will not be sorted. Example: lib/ or **/*.antler.html"
+        },
         "tailwindSorter.customPrefixes": {
           "type": "array",
           "items": {
@@ -701,8 +709,8 @@
     "@typescript-eslint/parser": "^6.15.0",
     "@vscode/test-cli": "^0.0.4",
     "@vscode/test-electron": "^2.3.8",
-    "sinon": "^17.0.1",
     "eslint": "^8.56.0",
+    "sinon": "^17.0.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.3",
     "webpack": "^5.89.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 
 import getClassesMap from "./getClassesMap";
-import getLanguages from "./lib/languages";
+import getLanguages, { normalize } from "./lib/languages";
 import sortTailwind from "./sortTailwind";
 
 // This method is called when your extension is activated
@@ -55,9 +55,19 @@ export async function sortOnCommand() {
 export function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
   const config = vscode.workspace.getConfiguration("tailwindSorter");
   const sortOnSave = config.get<boolean>("sortOnSave", true);
+  const ignorePaths = config.get<string[]>("ignorePaths", []);
   const languages = getLanguages();
 
-  if (!sortOnSave || !languages.includes(event.document.languageId)) {
+  const shouldIgnoreFile = ignorePaths.some(
+    (path) =>
+      vscode.languages.match({ pattern: normalize(path) }, event.document) > 0
+  );
+
+  if (
+    !sortOnSave ||
+    shouldIgnoreFile ||
+    !languages.includes(event.document.languageId)
+  ) {
     return;
   }
 
@@ -80,7 +90,7 @@ export function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
           event.document.positionAt(text.length)
         ),
         sortedTailwind
-      ),
+      )
     ])
   );
 }

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -41,3 +41,13 @@ export default function getLanguages() {
     (lang) => !excludeLanguages.includes(lang)
   );
 }
+
+/**
+ * Create a glob pattern from a simplified path
+ *
+ * @param path the path to glob
+ * @returns A normalized glob pattern
+ */
+export function normalize(path: string): string {
+  return path.endsWith("/") ? `**/${path}**` : path;
+}

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -23,7 +23,7 @@ const languages = [
   "css",
   "scss",
   "razor",
-  "aspnetcorerazor",
+  "aspnetcorerazor"
 ];
 
 /**
@@ -34,7 +34,10 @@ const languages = [
  */
 export default function getLanguages() {
   const config = workspace.getConfiguration("tailwindSorter");
-  const includedLanguages = config.get("includeLanguages", []);
+  const includedLanguages = config.get<string[]>("includeLanguages", []);
+  const excludeLanguages = config.get<string[]>("excludeLanguages", []);
 
-  return [...languages, ...includedLanguages];
+  return [...languages, ...includedLanguages].filter(
+    (lang) => !excludeLanguages.includes(lang)
+  );
 }

--- a/src/test/_createConfigStub.ts
+++ b/src/test/_createConfigStub.ts
@@ -19,6 +19,7 @@ export default function createConfigStub(options = {}) {
     sortOnSave: defaultSortOnSave,
     sectionOrder: defaultSectionOrder,
     includeLanguages: [],
+    excludeLanguages: []
   };
 
   const config = { ...defaults, ...options };
@@ -40,6 +41,8 @@ export default function createConfigStub(options = {}) {
                 return config.customPrefixes;
               case "includeLanguages":
                 return config.includeLanguages;
+              case "excludeLanguages":
+                return config.excludeLanguages;
               case "sortOnSave":
                 return config.sortOnSave;
               case "sectionOrder":
@@ -47,7 +50,7 @@ export default function createConfigStub(options = {}) {
               default:
                 return undefined;
             }
-          },
+          }
         } as vscode.WorkspaceConfiguration;
       }
       return {} as vscode.WorkspaceConfiguration;

--- a/src/test/_createConfigStub.ts
+++ b/src/test/_createConfigStub.ts
@@ -19,7 +19,8 @@ export default function createConfigStub(options = {}) {
     sortOnSave: defaultSortOnSave,
     sectionOrder: defaultSectionOrder,
     includeLanguages: [],
-    excludeLanguages: []
+    excludeLanguages: [],
+    ignorePaths: []
   };
 
   const config = { ...defaults, ...options };
@@ -43,6 +44,8 @@ export default function createConfigStub(options = {}) {
                 return config.includeLanguages;
               case "excludeLanguages":
                 return config.excludeLanguages;
+              case "ignorePaths":
+                return config.ignorePaths;
               case "sortOnSave":
                 return config.sortOnSave;
               case "sectionOrder":

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -49,7 +49,7 @@ suite("VS Code Configuration", () => {
     assert.ok(languages.includes("potatoscript"));
   });
 
-  test("getLanguages does not return languages excluded in config", () => {
+  test("getLanguages does not return languages excluded from config", () => {
     const before = getLanguages();
     assert.ok(before.includes("html"));
 
@@ -180,7 +180,25 @@ suite("VS Code Configuration", () => {
     assert.strictEqual(sortedTailwind.includes("grid hover:grid"), true);
   });
 
-  test("when file is saved, tailwind is not sorted if sortOnSave is false", async () => {
+  test("don't sort on save if language is not supported", async () => {
+    const document = {
+      languageId: "unsupported",
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    sinon.assert.notCalled(waitUntilSpy);
+  });
+
+  test("don't sort on save if sortOnSave is false", async () => {
     createConfigStub({ sortOnSave: false });
 
     const document = {
@@ -200,7 +218,79 @@ suite("VS Code Configuration", () => {
     sinon.assert.notCalled(waitUntilSpy);
   });
 
-  test("when file is saved, tailwind is sorted if sortOnSave is true", async () => {
+  test("don't sort on save if language is excluded via config", async () => {
+    createConfigStub({
+      excludeLanguages: ["html"]
+    });
+
+    const document = {
+      languageId: "html",
+      fileName: "file.html",
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    sinon.assert.notCalled(waitUntilSpy);
+  });
+
+  test("don't sort on save if file matches an ignore path", async () => {
+    createConfigStub({
+      ignorePaths: ["**/*.antlers.html"],
+      includeLanguages: ["html"]
+    });
+
+    const document = {
+      languageId: "html",
+      fileName: "file.antlers.html",
+      uri: { fsPath: "file.antlers.html" },
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    sinon.assert.notCalled(waitUntilSpy);
+  });
+
+  test("don't sort on save if file is in ignored directory", async () => {
+    createConfigStub({
+      ignorePaths: ["ignore/"]
+    });
+
+    const document = {
+      languageId: "html",
+      fileName: "src/deeply/nested/ignore/lib/file.html",
+      uri: { fsPath: "src/deeply/nested/ignore/lib/file.html" },
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    sinon.assert.notCalled(waitUntilSpy);
+  });
+
+  test("sort on save if sortOnSave is true", async () => {
     createConfigStub({ sortOnSave: true });
 
     const document = {

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -16,11 +16,11 @@ suite("VS Code Configuration", () => {
     createConfigStub({
       categories: {
         category1: ["class1", "class3"],
-        category2: ["class2", "class4"],
+        category2: ["class2", "class4"]
       },
       categoryOrder: { sortOrder: ["category1", "category2"] },
       pseudoClassesOrder: { sortOrder: ["pseudo2", "pseudo1"] },
-      sectionOrder: ["customClasses", "classes", "pseudoClasses"],
+      sectionOrder: ["customClasses", "classes", "pseudoClasses"]
     });
 
     const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
@@ -29,24 +29,46 @@ suite("VS Code Configuration", () => {
       class1: 0,
       class2: 2,
       class3: 1,
-      class4: 3,
+      class4: 3
     });
 
     assert.deepStrictEqual(pseudoSortOrder, ["pseudo2", "pseudo1"]);
     assert.deepStrictEqual(sectionOrder, [
       "customClasses",
       "classes",
-      "pseudoClasses",
+      "pseudoClasses"
     ]);
   });
 
   test("getLanguages includes custom languages from config", () => {
     createConfigStub({
-      includeLanguages: ["potatoscript"],
+      includeLanguages: ["potatoscript"]
     });
 
     const languages = getLanguages();
     assert.ok(languages.includes("potatoscript"));
+  });
+
+  test("getLanguages does not return languages excluded in config", () => {
+    const before = getLanguages();
+    assert.ok(before.includes("html"));
+
+    createConfigStub({
+      excludeLanguages: ["html"]
+    });
+
+    const languages = getLanguages();
+    assert.strictEqual(languages.includes("html"), false);
+  });
+
+  test("getLanguages prioritizes excludeLanguages over includeLanguages", () => {
+    createConfigStub({
+      excludeLanguages: ["jellyfish"],
+      includeLanguages: ["jellyfish"]
+    });
+
+    const languages = getLanguages();
+    assert.strictEqual(languages.includes("jellyfish"), false);
   });
 
   test("don't sort on command if language is not supported", async () => {
@@ -58,7 +80,7 @@ suite("VS Code Configuration", () => {
     const document = {
       languageId: "unsupported",
       getText: () => "<div class='hover:grid grid'></div>",
-      positionAt: (offset: number) => new vscode.Position(0, offset),
+      positionAt: (offset: number) => new vscode.Position(0, offset)
     } as vscode.TextDocument;
 
     const replaceStub = sinon.stub();
@@ -71,7 +93,7 @@ suite("VS Code Configuration", () => {
 
     const activeTextEditor = {
       document,
-      edit: editSpy,
+      edit: editSpy
     } as unknown as vscode.TextEditor;
     sinon.stub(vscode.window, "activeTextEditor").get(() => activeTextEditor);
 
@@ -91,7 +113,7 @@ suite("VS Code Configuration", () => {
     const document = {
       languageId: "html",
       getText: () => "<div class='hover:grid grid'></div>",
-      positionAt: (offset: number) => new vscode.Position(0, offset),
+      positionAt: (offset: number) => new vscode.Position(0, offset)
     } as vscode.TextDocument;
 
     const replaceStub = sinon.stub();
@@ -104,7 +126,7 @@ suite("VS Code Configuration", () => {
 
     const activeTextEditor = {
       document,
-      edit: editSpy,
+      edit: editSpy
     } as unknown as vscode.TextEditor;
     sinon.stub(vscode.window, "activeTextEditor").get(() => activeTextEditor);
 
@@ -120,7 +142,7 @@ suite("VS Code Configuration", () => {
 
   test("sort on command if language is included via config", async () => {
     createConfigStub({
-      includeLanguages: ["potatoscript"],
+      includeLanguages: ["potatoscript"]
     });
 
     const showWarningMessageStub = sinon.stub(
@@ -131,7 +153,7 @@ suite("VS Code Configuration", () => {
     const document = {
       languageId: "potatoscript",
       getText: () => "<div class='hover:grid grid'></div>",
-      positionAt: (offset: number) => new vscode.Position(0, offset),
+      positionAt: (offset: number) => new vscode.Position(0, offset)
     } as vscode.TextDocument;
 
     const replaceStub = sinon.stub();
@@ -144,7 +166,7 @@ suite("VS Code Configuration", () => {
 
     const activeTextEditor = {
       document,
-      edit: editSpy,
+      edit: editSpy
     } as unknown as vscode.TextEditor;
     sinon.stub(vscode.window, "activeTextEditor").get(() => activeTextEditor);
 
@@ -164,7 +186,7 @@ suite("VS Code Configuration", () => {
     const document = {
       languageId: "html",
       getText: () => "<div class='hover:grid grid'></div>",
-      positionAt: (offset: number) => new vscode.Position(0, offset),
+      positionAt: (offset: number) => new vscode.Position(0, offset)
     } as vscode.TextDocument;
 
     const waitUntilSpy = sinon.spy();
@@ -172,7 +194,7 @@ suite("VS Code Configuration", () => {
     sortOnSave({
       document,
       waitUntil: waitUntilSpy,
-      reason: vscode.TextDocumentSaveReason.Manual,
+      reason: vscode.TextDocumentSaveReason.Manual
     } as vscode.TextDocumentWillSaveEvent);
 
     sinon.assert.notCalled(waitUntilSpy);
@@ -184,7 +206,7 @@ suite("VS Code Configuration", () => {
     const document = {
       languageId: "html",
       getText: () => "<div class='hover:grid grid'></div>",
-      positionAt: (offset: number) => new vscode.Position(0, offset),
+      positionAt: (offset: number) => new vscode.Position(0, offset)
     } as vscode.TextDocument;
 
     const waitUntilSpy = sinon.spy();
@@ -192,7 +214,7 @@ suite("VS Code Configuration", () => {
     sortOnSave({
       document,
       waitUntil: waitUntilSpy,
-      reason: vscode.TextDocumentSaveReason.Manual,
+      reason: vscode.TextDocumentSaveReason.Manual
     } as vscode.TextDocumentWillSaveEvent);
 
     sinon.assert.calledOnce(waitUntilSpy);


### PR DESCRIPTION
Allow files to be skipped when sorting via:
- exclude file extension config
- ignore file path config