### PR TITLE
Add use official sort config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Custom sort order and categories can be configured in settings
 - [Exclude Languages](vscode://settings/tailwindSorter.excludeLanguages): Language identifiers to remove from the list of supported languages. Files with these language identifiers will not be sorted.
 - [Ignore Paths](vscode://settings/tailwindSorter.ignorePaths): File paths to ignore. File names matching these glob patterns will not be sorted.
 - [Sort on Save](vscode://settings/tailwindSorter.sortOnSave): Whether or not classes should be sorted on save.
+- [Use Official Sort](vscode://settings/tailwindSorter.useOfficialSort): Use the [official TailwindCSS Prettier plugin](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier) sort order. Overrides all other sort settings. *Experimental*
 
 **The default category order is**: box model, grid, flex box, background, margins and padding, borders, width and height, typography, transformations, and other.
 
@@ -51,7 +52,6 @@ Custom sort order and categories can be configured in settings
       "inset-",
     ],
 ```
-
 
 **The default section order is**: classes (bg, text, etc.) then custom classes (non-Tailwind). By default, pseudo classes (hover:, sm:, etc.) are included in the classes section unless specified otherwise.
 
@@ -84,8 +84,14 @@ Alternatively, you can add additional [language identifiers](./CONTRIBUTING.md#1
 
 #### With Prettier
 
-If you don't need control over the sort order, [the prettier plugin](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier) is recommended.
+> *Experimental* please [report any issues](https://github.com/dejmedus/tailwind-sorter/issues)
+
+You can override the extensions native sorting by turning on the [Use Official Sort](vscode://settings/tailwindSorter.useOfficialSort) setting, which loads the TailwindCSS Prettier plugin sort order. 
+
+---
+
+If you use prettier, [the prettier plugin](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier) is recommended.
 
 - Using prettier-plugin-tailwindcss alongside Tailwind Sorter causes classes to "flash" on save.
-- To prevent this, remove `prettier-plugin-tailwindcss` from `plugins: []` in your prettier config file and reload window.
+- To prevent this, disable this extension or remove `prettier-plugin-tailwindcss` from `plugins: []` in your prettier config file and reload window.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tailwind-sorter",
       "version": "0.1.51",
       "license": "MIT",
+      "dependencies": {
+        "prettier-plugin-tailwindcss": "^0.8.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
@@ -3435,6 +3438,100 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
+      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
           "default": true,
           "description": "Sort Tailwind classes on save"
         },
+        "tailwindSorter.useOfficialSort": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use the official TailwindCSS sorting API rather than native sort order and logic."
+        },
         "tailwindSorter.sectionOrder": {
           "type": "array",
           "items": {
@@ -715,5 +720,8 @@
     "typescript": "^5.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "prettier-plugin-tailwindcss": "^0.8.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
 
+import type { SortOptions } from "./types";
+
 import getClassesMap from "./getClassesMap";
 import getLanguages, { normalize } from "./lib/languages";
 import sortTailwind from "./sortTailwind";
@@ -31,15 +33,12 @@ export async function sortOnCommand() {
     return;
   }
 
-  const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
-
   const text = document.getText();
-  const sortedTailwind = sortTailwind(
-    text,
-    classesMap,
-    pseudoSortOrder,
-    sectionOrder
-  );
+
+  const config = vscode.workspace.getConfiguration("tailwindSorter");
+  const useOfficialSort = config.get<boolean>("useOfficialSort", false);
+
+  const sortedTailwind = await sort(text, useOfficialSort);
 
   await editor.edit((editBuilder) => {
     editBuilder.replace(
@@ -71,19 +70,12 @@ export function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
     return;
   }
 
-  const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
-
   const text = event.document.getText();
-  const sortedTailwind = sortTailwind(
-    text,
-    classesMap,
-    pseudoSortOrder,
-    sectionOrder
-  );
 
-  // onWillSave + waitUntil prevents looping
+  const useOfficialSort = config.get<boolean>("useOfficialSort", false);
+
   event.waitUntil(
-    Promise.resolve([
+    sort(text, useOfficialSort).then((sortedTailwind) => [
       new vscode.TextEdit(
         new vscode.Range(
           event.document.positionAt(0),
@@ -93,6 +85,51 @@ export function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
       )
     ])
   );
+}
+
+/**
+ * Sort tailwind classes
+ *
+ * @param text file text containing tailwind classes to sort
+ * @param useOfficialSort whether or not to override native sort
+ * @returns sorted file text
+ */
+async function sort(text: string, useOfficialSort: boolean): Promise<string> {
+  if (useOfficialSort) {
+    try {
+      return sortTailwind(text, {
+        mode: "official",
+        sorter: await getOfficialSorter()
+      });
+    } catch {
+      return text;
+    }
+  }
+
+  return sortTailwind(text, { mode: "extension", ...getClassesMap() });
+}
+
+// Public sorting api exposed by prettier-plugin-tailwindcss
+// https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/438
+export let officialSorterPromise: Promise<any> | null = null;
+export function getOfficialSorter() {
+  if (!officialSorterPromise) {
+    officialSorterPromise = import("prettier-plugin-tailwindcss/sorter")
+      .then(({ createSorter }) => createSorter({}))
+      .catch(() => {
+        officialSorterPromise = null;
+        vscode.window.showWarningMessage(
+          "Tailwind Sorter: Failed to load official sorter, file was not sorted."
+        );
+        throw new Error("Failed to load official sorter");
+      });
+  }
+  return officialSorterPromise;
+}
+
+// Test helper
+export function resetOfficialSorterPromise() {
+  officialSorterPromise = null;
 }
 
 // This method is called when your extension is deactivated

--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -1,3 +1,4 @@
+import { SortOptions } from "./types";
 import {
   createApplyRegex,
   createRegex,
@@ -10,25 +11,12 @@ import {
  * Sorts the tailwind classes in the given file text based on the provided sort config.
  *
  * @param text - The file text to be sorted.
- * @param sortConfig - The sort config object that maps style classes to their sort order index.
- * @param pseudoClasses - An array of pseudo classes to sort by.
- * @returns The file text with sorted style classes.
+ * @param sortOptions - The sort mode and config.
  */
-export default function sortTailwind(
-  text: string,
-  sortConfig: { [key: string]: number },
-  pseudoClasses: string[],
-  sectionOrder: string[]
-) {
+export default function sortTailwind(text: string, sortOptions: SortOptions) {
   const applyRegex = createApplyRegex();
   text = text.replace(applyRegex, (match, classesGroup) => {
-    return sortFoundTailwind(
-      match,
-      classesGroup,
-      sortConfig,
-      pseudoClasses,
-      sectionOrder
-    );
+    return sortFoundTailwind(match, classesGroup, sortOptions);
   });
 
   const regex = createRegex();
@@ -45,13 +33,7 @@ export default function sortTailwind(
       const quotesGroup =
         singleQuotesGroup || doubleQuotesGroup || backtickQuotesGroup;
 
-      return sortFoundTailwind(
-        match,
-        quotesGroup,
-        sortConfig,
-        pseudoClasses,
-        sectionOrder
-      );
+      return sortFoundTailwind(match, quotesGroup, sortOptions);
     }
   );
 
@@ -63,16 +45,12 @@ export default function sortTailwind(
  *
  * @param match - The full match found by regex. ex: class="bg-blue-500 text-white"
  * @param classesStr - The tailwind classes. ex: bg-blue-500 text-white
- * @param sortConfig - The sort config object that maps style classes to their sort order index.
- * @param pseudoClasses - An array of pseudo classes to sort by.
- * @param sectionOrder - The order of classes, pseudo classes, and custom classes
+ * @param sortOptions - The sort mode and config.
  */
 function sortFoundTailwind(
   match: string,
   classesStr: string,
-  sortConfig: { [key: string]: number },
-  pseudoClasses: string[],
-  sectionOrder: string[]
+  sortOptions: SortOptions
 ) {
   if (!classesStr || !classesStr.includes(" ")) {
     return match;
@@ -85,6 +63,16 @@ function sortFoundTailwind(
   if (groupContainsDynamicSyntax) {
     return match;
   }
+
+  if (sortOptions.mode === "official") {
+    const sortedClasses = sortOptions.sorter.sortClassAttributes([
+      classesStr
+    ])[0];
+
+    return match.replace(classesStr, sortedClasses);
+  }
+
+  const { classesMap, pseudoSortOrder, sectionOrder } = sortOptions;
 
   const classes = classesStr
     .split(/\s+/)
@@ -103,8 +91,8 @@ function sortFoundTailwind(
   };
 
   const sortedClasses = classes.sort((aClass: string, bClass: string) => {
-    const [aIndex, aIsPseudo] = findIndex(aClass, bases, sortConfig, classes);
-    const [bIndex, bIsPseudo] = findIndex(bClass, bases, sortConfig, classes);
+    const [aIndex, aIsPseudo] = findIndex(aClass, bases, classesMap, classes);
+    const [bIndex, bIsPseudo] = findIndex(bClass, bases, classesMap, classes);
 
     if (aIndex !== bIndex) {
       return aIndex - bIndex;
@@ -112,7 +100,7 @@ function sortFoundTailwind(
 
     if (aIsPseudo && bIsPseudo) {
       // sort pseudo classes by config order
-      return comparePseudoClasses(aClass, bClass, pseudoClasses);
+      return comparePseudoClasses(aClass, bClass, pseudoSortOrder);
     }
 
     // otherwise sort alphabetically
@@ -230,18 +218,30 @@ function comparePseudoClasses(
     let bPseudo = pseudoClasses.find((c) => bPseudoClass.includes(c));
 
     if (pseudoClasses.includes("support-")) {
-      if (aPseudoClass.includes("support-")) aPseudo = "support-";
-      if (bPseudoClass.includes("support-")) bPseudo = "support-";
+      if (aPseudoClass.includes("support-")) {
+        aPseudo = "support-";
+      }
+      if (bPseudoClass.includes("support-")) {
+        bPseudo = "support-";
+      }
     }
 
     if (pseudoClasses.includes("group-")) {
-      if (aPseudoClass.includes("group-")) aPseudo = "group-";
-      if (bPseudoClass.includes("group-")) bPseudo = "group-";
+      if (aPseudoClass.includes("group-")) {
+        aPseudo = "group-";
+      }
+      if (bPseudoClass.includes("group-")) {
+        bPseudo = "group-";
+      }
     }
 
     if (pseudoClasses.includes("peer-")) {
-      if (aPseudoClass.includes("peer-")) aPseudo = "peer-";
-      if (bPseudoClass.includes("peer-")) bPseudo = "peer-";
+      if (aPseudoClass.includes("peer-")) {
+        aPseudo = "peer-";
+      }
+      if (bPseudoClass.includes("peer-")) {
+        bPseudo = "peer-";
+      }
     }
 
     if (aPseudo && bPseudo) {

--- a/src/sortTailwind.ts
+++ b/src/sortTailwind.ts
@@ -217,12 +217,12 @@ function comparePseudoClasses(
     let aPseudo = pseudoClasses.find((c) => aPseudoClass.includes(c));
     let bPseudo = pseudoClasses.find((c) => bPseudoClass.includes(c));
 
-    if (pseudoClasses.includes("support-")) {
-      if (aPseudoClass.includes("support-")) {
-        aPseudo = "support-";
+    if (pseudoClasses.includes("supports-")) {
+      if (aPseudoClass.includes("supports-")) {
+        aPseudo = "supports-";
       }
-      if (bPseudoClass.includes("support-")) {
-        bPseudo = "support-";
+      if (bPseudoClass.includes("supports-")) {
+        bPseudo = "supports-";
       }
     }
 

--- a/src/test/_createConfigStub.ts
+++ b/src/test/_createConfigStub.ts
@@ -20,7 +20,8 @@ export default function createConfigStub(options = {}) {
     sectionOrder: defaultSectionOrder,
     includeLanguages: [],
     excludeLanguages: [],
-    ignorePaths: []
+    ignorePaths: [],
+    useOfficialSort: false
   };
 
   const config = { ...defaults, ...options };
@@ -50,6 +51,8 @@ export default function createConfigStub(options = {}) {
                 return config.sortOnSave;
               case "sectionOrder":
                 return config.sectionOrder;
+              case "useOfficialSort":
+                return config.useOfficialSort;
               default:
                 return undefined;
             }

--- a/src/test/_sortHelper.ts
+++ b/src/test/_sortHelper.ts
@@ -1,9 +1,23 @@
 import sortTailwind from "../sortTailwind";
-import { defaultClassesMap } from "./_defaultClassMap";
+import getClassesMap from "../getClassesMap";
 
 const sortHelper = (unsortedStr: string) => {
-    const { classesMap, pseudoSortOrder, sectionOrder } = defaultClassesMap();
-    return sortTailwind(unsortedStr, classesMap, pseudoSortOrder, sectionOrder);
+  const { classesMap, pseudoSortOrder, sectionOrder } = getClassesMap();
+
+  return sortTailwind(unsortedStr, {
+    mode: "extension",
+    classesMap,
+    pseudoSortOrder,
+    sectionOrder
+  });
 };
 
+const officialSortHelper = (unsortedStr: string, sorter: any) => {
+  return sortTailwind(unsortedStr, {
+    mode: "official",
+    sorter
+  });
+};
+
+export { officialSortHelper };
 export default sortHelper;

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -2,7 +2,11 @@ import * as vscode from "vscode";
 import * as assert from "assert";
 import * as sinon from "sinon";
 
-import { sortOnSave } from "../extension";
+import {
+  sortOnSave,
+  officialSorterPromise,
+  resetOfficialSorterPromise
+} from "../extension";
 import getClassesMap from "../getClassesMap";
 import createConfigStub from "./_createConfigStub";
 import getLanguages from "../lib/languages";
@@ -10,6 +14,7 @@ import getLanguages from "../lib/languages";
 suite("VS Code Configuration", () => {
   teardown(() => {
     sinon.restore();
+    resetOfficialSorterPromise();
   });
 
   test("getClassesMap respects config", () => {
@@ -181,28 +186,10 @@ suite("VS Code Configuration", () => {
   });
 
   test("don't sort on save if language is not supported", async () => {
+    createConfigStub({ sortOnSave: true });
+
     const document = {
       languageId: "unsupported",
-      getText: () => "<div class='hover:grid grid'></div>",
-      positionAt: (offset: number) => new vscode.Position(0, offset)
-    } as vscode.TextDocument;
-
-    const waitUntilSpy = sinon.spy();
-
-    sortOnSave({
-      document,
-      waitUntil: waitUntilSpy,
-      reason: vscode.TextDocumentSaveReason.Manual
-    } as vscode.TextDocumentWillSaveEvent);
-
-    sinon.assert.notCalled(waitUntilSpy);
-  });
-
-  test("don't sort on save if sortOnSave is false", async () => {
-    createConfigStub({ sortOnSave: false });
-
-    const document = {
-      languageId: "html",
       getText: () => "<div class='hover:grid grid'></div>",
       positionAt: (offset: number) => new vscode.Position(0, offset)
     } as vscode.TextDocument;
@@ -290,6 +277,50 @@ suite("VS Code Configuration", () => {
     sinon.assert.notCalled(waitUntilSpy);
   });
 
+  test("don't sort on save if sortOnSave is false", async () => {
+    createConfigStub({ sortOnSave: false });
+
+    const document = {
+      languageId: "html",
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    sinon.assert.notCalled(waitUntilSpy);
+  });
+
+  test("sort on save if language is included via config", async () => {
+    createConfigStub({ sortOnSave: true, includeLanguages: ["potatoscript"] });
+
+    const document = {
+      languageId: "potatoscript",
+      getText: () => "<div class='hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    sinon.assert.calledOnce(waitUntilSpy);
+
+    const textEdit = await waitUntilSpy.firstCall.args[0];
+    const sortedTailwind = textEdit[0].newText;
+    assert.strictEqual(sortedTailwind.includes("grid hover:grid"), true);
+  });
+
   test("sort on save if sortOnSave is true", async () => {
     createConfigStub({ sortOnSave: true });
 
@@ -313,5 +344,60 @@ suite("VS Code Configuration", () => {
     const sortedTailwind = textEdit[0].newText;
 
     assert.strictEqual(sortedTailwind.includes("grid hover:grid"), true);
+  });
+
+  test("official sorter is loaded if useOfficialSort is true", async () => {
+    createConfigStub({
+      sortOnSave: true,
+      useOfficialSort: true
+    });
+
+    const document = {
+      languageId: "html",
+      getText: () => "<div class='grid grid hover:grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    assert.ok(officialSorterPromise);
+    sinon.assert.calledOnce(waitUntilSpy);
+
+    const textEdit = await waitUntilSpy.firstCall.args[0];
+    const sortedTailwind = textEdit[0].newText;
+
+    assert.strictEqual(sortedTailwind.includes("grid hover:grid"), true);
+  });
+
+  test("official sorter is not loaded if useOfficialSort is false", async () => {
+    createConfigStub({ sortOnSave: true });
+
+    const document = {
+      languageId: "html",
+      getText: () => "<div class='grid hover:grid grid'></div>",
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    } as vscode.TextDocument;
+
+    const waitUntilSpy = sinon.spy();
+
+    sortOnSave({
+      document,
+      waitUntil: waitUntilSpy,
+      reason: vscode.TextDocumentSaveReason.Manual
+    } as vscode.TextDocumentWillSaveEvent);
+
+    assert.strictEqual(officialSorterPromise, null);
+    sinon.assert.calledOnce(waitUntilSpy);
+
+    const textEdit = await waitUntilSpy.firstCall.args[0];
+    const sortedTailwind = textEdit[0].newText;
+
+    assert.strictEqual(sortedTailwind.includes("grid grid hover:grid"), true);
   });
 });

--- a/src/test/section-order.test.ts
+++ b/src/test/section-order.test.ts
@@ -1,104 +1,84 @@
 import * as assert from "assert";
+import { restore } from "sinon";
 
-import sortTailwind from "../sortTailwind";
-import { defaultClassesMap } from "./_defaultClassMap";
+import createConfigStub from "./_createConfigStub";
+import sortHelper from "./_sortHelper";
 
 suite("Section Order", () => {
-  const { classesMap, pseudoSortOrder } = defaultClassesMap();
+  teardown(() => {
+    restore();
+  });
 
   test('default ["classes", "customClasses"]', () => {
+    createConfigStub({ sectionOrder: ["classes", "customClasses"] });
+
     const unsortedString = `<div class="hover:bg-blue-500 potato flex bg-black custom text-white lg:text-gray-100">`;
     const sortedString = `<div class="flex bg-black hover:bg-blue-500 text-white lg:text-gray-100 potato custom">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "classes",
-        "customClasses"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test('["customClasses", "classes"]', () => {
+    createConfigStub({ sectionOrder: ["customClasses", "classes"] });
+
     const unsortedString = `<div class="hover:bg-blue-500 flex custom bg-black text-white potato lg:text-gray-100">`;
     const sortedString = `<div class="custom potato flex bg-black hover:bg-blue-500 text-white lg:text-gray-100">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "customClasses",
-        "classes"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test('["classes", "pseudoClasses"]', () => {
+    createConfigStub({
+      sectionOrder: ["classes", "pseudoClasses", "customClasses"]
+    });
+
     const unsortedString = `<div class="flex flex-col md:flex-row justify-between gap-4 p-4 md:p-8 bg-background">`;
     const sortedString = `<div class="flex flex-col justify-between gap-4 bg-background p-4 md:flex-row md:p-8">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "classes",
-        "pseudoClasses",
-        "customClasses"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test('["classes", "pseudoClasses", "customClasses"]', () => {
+    createConfigStub({
+      sectionOrder: ["classes", "pseudoClasses", "customClasses"]
+    });
+
     const unsortedString = `<div class="hover:bg-blue-500 flex custom bg-black text-white potato lg:text-gray-100">`;
     const sortedString = `<div class="flex bg-black text-white hover:bg-blue-500 lg:text-gray-100 custom potato">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "classes",
-        "pseudoClasses",
-        "customClasses"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test('["pseudoClasses", "classes", "customClasses"]', () => {
+    createConfigStub({
+      sectionOrder: ["pseudoClasses", "classes", "customClasses"]
+    });
+
     const unsortedString = `<div class="hover:bg-blue-500 flex custom bg-black frog potato text-white lg:text-gray-100">`;
     const sortedString = `<div class="hover:bg-blue-500 lg:text-gray-100 flex bg-black text-white custom frog potato">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "pseudoClasses",
-        "classes",
-        "customClasses"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test('["customClasses", "classes", "pseudoClasses"]', () => {
+    createConfigStub({
+      sectionOrder: ["customClasses", "classes", "pseudoClasses"]
+    });
+
     const unsortedString = `<div class="hover:bg-blue-500 flex frog bg-black text-white lg:text-gray-100 custom">`;
     const sortedString = `<div class="frog custom flex bg-black text-white hover:bg-blue-500 lg:text-gray-100">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "customClasses",
-        "classes",
-        "pseudoClasses"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test('["classes", "customClasses", "pseudoClasses"]', () => {
+    createConfigStub({
+      sectionOrder: ["classes", "customClasses", "pseudoClasses"]
+    });
+
     const unsortedString = `<div class="hover:bg-blue-500 flex bg-black text-white potato lg:text-gray-100 custom">`;
     const sortedString = `<div class="flex bg-black text-white potato custom hover:bg-blue-500 lg:text-gray-100">`;
 
-    assert.strictEqual(
-      sortTailwind(unsortedString, classesMap, pseudoSortOrder, [
-        "classes",
-        "customClasses",
-        "pseudoClasses"
-      ]),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 });

--- a/src/test/sorting-official.test.ts
+++ b/src/test/sorting-official.test.ts
@@ -1,0 +1,84 @@
+import * as assert from "assert";
+import { restore } from "sinon";
+
+import createConfigStub from "./_createConfigStub";
+import { officialSortHelper } from "./_sortHelper";
+
+import { getOfficialSorter } from "../extension";
+
+suite("Official Tailwind Plugin Sorting", () => {
+  let sorter: any;
+
+  suiteSetup(async () => {
+    sorter = await getOfficialSorter();
+  });
+
+  teardown(() => {
+    restore();
+  });
+
+  test('Correct sort class=""', () => {
+    createConfigStub({});
+
+    const unsortedString = `<div class="font-semibold after:content-[''] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[''] items-center" blah blah`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+
+  test("Correct sort className=''", () => {
+    const unsortedString = `<div className='font-semibold after:content-[""] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[""] items-center' blah blah`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+
+  test("Kitchen sink", () => {
+    const unsortedString = `<div class="text-center after:content-[''] sm:hover:bg-[url('/noise.png')] border-4 -mt-2 hover:focus:rotate-3 lg:dark:bg-gradient-to-tr translate-x-1/2 before:opacity-50 w-[calc(100%-4rem)] flex-col focus-within:ring-4 grid-cols-3 h-screen text-3xl font-black absolute justify-between sm:peer-checked:translate-y-3 hover:skew-x-6 md:max-w-3xl text-blue-500 bg-cover md:grid p-10 bg-center flex bg-no-repeat underline gap-6 sm:w-1/2 sm:bg-yellow-400 bg-[radial-gradient(circle_at_top_left,#1e3a8a,#9333ea)] z-50 sticky rounded-xl hover:contrast-125 hover:shadow-2xl lg:mt-10 lg:pl-8 group-hover:opacity-90 sm:even:translate-x-4 sm:hover:scale-105 text-balance peer-invalid:ring-red-500 overflow-hidden min-h-[50vh] md:py-12 dark:hover:brightness-75 bg-fixed hover:text-white sm:dark:text-green-400 before:absolute sm:translate-x-2 sm:text-lg md:backdrop-blur-xl select-none" blah blah>`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+
+  test("Only pseudo classes", () => {
+    const unsortedString = `<div class="focus-within:ring-blue-200 group-hover:text-blue-500 focus-within:ring" blah blah`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+
+  test("Data and aria attributes", () => {
+    const unsortedString = `<div class="hover:bg-red-500 aria-[expanded=true]:bg-green-500 hover:bg-blue-500 data-[open=true]:bg-blue-500">`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+
+  test("Container queries", () => {
+    const unsortedString = `<div class="@lg:flex group-hover:text-blue-500 flex @md:flex @sm:flex text-black"`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+
+  test("Arbitrary values", () => {
+    const unsortedString = `<div className='h-[calc(100%-1rem)] w-[100px] bg-[#1a1a1a] w-[100px]' blah blah`;
+
+    assert.notStrictEqual(
+      officialSortHelper(unsortedString, sorter),
+      unsortedString
+    );
+  });
+});

--- a/src/test/sorting.test.ts
+++ b/src/test/sorting.test.ts
@@ -13,20 +13,14 @@ suite("Sorting", () => {
     const sortedString = `<div class="flex flex-col flex-1 items-center gap-20 bg-black lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 w-full font-sans font-semibold before:content-[''] after:content-['']" blah blah`;
     const unsortedString = `<div class="font-semibold after:content-[''] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[''] items-center" blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Correct sort className=''", () => {
     const sortedString = `<div className='flex flex-col flex-1 items-center gap-20 bg-black lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 w-full font-sans font-semibold before:content-[""] after:content-[""]' blah blah`;
     const unsortedString = `<div className='font-semibold after:content-[""] flex-1 flex-col gap-20 lg:bg-pink hover:bg-purple bg-gradient-to-r from-green-300 bg-black via-blue-500 to-purple-600 flex w-full font-sans before:content-[""] items-center' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Kitchen sink", () => {
@@ -34,40 +28,28 @@ suite("Sorting", () => {
 
     const sortedString = `<div class="z-50 absolute before:absolute sticky flex flex-col justify-between gap-6 md:grid grid-cols-3 bg-[radial-gradient(circle_at_top_left,#1e3a8a,#9333ea)] sm:bg-yellow-400 sm:hover:bg-[url('/noise.png')] lg:dark:bg-gradient-to-tr bg-cover bg-no-repeat bg-center bg-fixed before:opacity-50 group-hover:opacity-90 hover:shadow-2xl md:backdrop-blur-xl dark:hover:brightness-75 -mt-2 lg:mt-10 p-10 md:py-12 lg:pl-8 border-4 rounded-xl focus-within:ring-4 peer-invalid:ring-red-500 w-[calc(100%-4rem)] sm:w-1/2 md:max-w-3xl h-screen min-h-[50vh] overflow-hidden font-black text-blue-500 sm:dark:text-green-400 hover:text-white sm:text-lg text-3xl text-center underline text-balance after:content-[''] hover:focus:rotate-3 sm:hover:scale-105 hover:skew-x-6 translate-x-1/2 sm:even:translate-x-4 sm:peer-checked:translate-y-3 sm:translate-x-2 select-none hover:contrast-125" blah blah>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Non tailwind classes with - sort to end", () => {
     const sortedString = `<div className='relative flex justify-center self-center lg:self-start -ml-5 lg:ml-0 w-[375px] lg:w-[568px] h-[375px] lg:h-[568px] custom shape-wrapper'`;
     const unsortedString = `<div className='lg:self-start -ml-5 relative justify-center custom self-center lg:ml-0 shape-wrapper w-[375px] lg:w-[568px] h-[375px] lg:h-[568px] flex'`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Non tailwind classes keep their sort order", () => {
     const sortedString = `<div class="flex flex-col flex-1 carrot banana apple" blah blah`;
     const unsortedString = `<div class="flex-col carrot flex-1 banana flex apple" blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Non tailwind classes w duplicates keep their sort order", () => {
     const sortedString = `<div class="flex flex-col flex-1 banana carrot-1 carrot-1 hover:carrot apple" blah blah`;
     const unsortedString = `<div class="banana carrot-1 flex-col carrot-1 hover:carrot flex-1 apple flex" blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Non tailwind classes w prefix keep their sort order", () => {
@@ -75,90 +57,63 @@ suite("Sorting", () => {
     const sortedString = `<div class="tw:px-4 tw-text-2xl foo bar"><div>`;
     const unsortedString = `<div class="foo bar tw-text-2xl tw:px-4"><div>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Custom color shares name with tailwind class", () => {
     const sortedString = `<div className='flex bg-blue-500 bg-inverted/25 bg-white grayscale invert' blah blah`;
     const unsortedString = `<div className='flex grayscale bg-white bg-inverted/25 bg-blue-500 invert' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("One word sort", () => {
     const sortedString = `<div className='flex' blah blah`;
     const unsortedString = `<div className='flex' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Empty string present", () => {
     const sortedString = `<div className=''></div><div className='flex flex-col' blah blah`;
     const unsortedString = `<div className=''></div><div className='flex-col flex' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Multi string types", () => {
     const sortedString = `<div className="flex flex-col"></div><div className='flex flex-col' blah blah`;
     const unsortedString = `<div className="flex-col flex"></div><div className='flex-col flex' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Repeat classes", () => {
     const sortedString = `<div className="top-0 left-0 left-0 left-10 lg:static fixed flex justify-center"`;
     const unsortedString = `<div className="top-0 left-10 left-0 lg:static fixed flex justify-center left-0"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Repeat classes w pseudos", () => {
     const sortedString = `<div className="top-0 hover:lg:left-0 hover:lg:left-0 hover:lg:left-10 lg:static fixed flex justify-center"`;
     const unsortedString = `<div className="top-0 hover:lg:left-10 hover:lg:left-0 lg:static fixed flex justify-center hover:lg:left-0"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Only pseudo classes", () => {
     const sortedString = `<div class="focus-within:ring focus-within:ring-blue-200 group-hover:text-blue-500" blah blah`;
     const unsortedString = `<div class="focus-within:ring-blue-200 group-hover:text-blue-500 focus-within:ring" blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("-not pseudo classes", () => {
     const sortedString = `<div class="bg-indigo-600 hover:not-lg:bg-indigo-700 hover:not-xl:bg-indigo-700 hover:not-focus:bg-indigo-700"`;
     const unsortedString = `<div class="hover:not-xl:bg-indigo-700 bg-indigo-600 hover:not-focus:bg-indigo-700 hover:not-lg:bg-indigo-700"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   // https://tailwindcss.com/docs/hover-focus-and-other-states#supports
@@ -166,240 +121,168 @@ suite("Sorting", () => {
     const sortedString = `<div class="supports-[display:flex]:flex supports-[display:grid]:grid supports-backdrop-filter:bg-black/25">`;
     const unsortedString = `<div class="supports-backdrop-filter:bg-black/25 supports-[display:flex]:flex supports-[display:grid]:grid">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Complex arbitrary []", () => {
     const sortedString = `<div class="[&:nth-child(3)]:bg-blue-500 [&>*:not(:first-child)]:mt-2">`;
     const unsortedString = `<div class="[&>*:not(:first-child)]:mt-2 [&:nth-child(3)]:bg-blue-500">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("-not variants with pseudo classes", () => {
     const sortedString = `<div class="4xl:not-disabled:bg-pink-400 5xl:not-disabled:bg-blue-500 max-6xl:not-disabled:bg-green-500">`;
     const unsortedString = `<div class="max-6xl:not-disabled:bg-green-500 5xl:not-disabled:bg-blue-500 4xl:not-disabled:bg-pink-400">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Screen size pseudo classes", () => {
     const sortedString = `<div class="sm:hover:bg-blue-500 md:visited:bg-red-600 md:group-hover:bg-red-500 lg:focus-within:bg-green-500">`;
     const unsortedString = `<div class="md:visited:bg-red-600 lg:focus-within:bg-green-500 sm:hover:bg-blue-500 md:group-hover:bg-red-500">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("group-", () => {
     const sortedString = `<div class="hover:bg-pink-500 focus-within:bg-green-500 group-hover:bg-blue-500"`;
     const unsortedString = `<div class="group-hover:bg-blue-500 focus-within:bg-green-500 hover:bg-pink-500"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Group and peer variants", () => {
     const sortedString = `<div class="2xl:hover:bg-blue-400 hover:bg-blue-500 group-hover:bg-pink-500 peer-hover:bg-yellow-500">`;
     const unsortedString = `<div class="peer-hover:bg-yellow-500 2xl:hover:bg-blue-400 group-hover:bg-pink-500 hover:bg-blue-500">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Group/ and group-hover/", () => {
     const sortedString = `<a class="group/edit invisible group-hover/item:visible" href="tel:{person.phone}">`;
     const unsortedString = `<a class="group-hover/item:visible invisible group/edit" href="tel:{person.phone}">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Data and aria attributes", () => {
     const sortedString = `<div class="data-[open=true]:bg-blue-500 aria-[expanded=true]:bg-green-500 hover:bg-red-500">`;
     const unsortedString = `<div class="hover:bg-red-500 aria-[expanded=true]:bg-green-500 data-[open=true]:bg-blue-500">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Chained container queries", () => {
     const sortedString = `<div class="flex @sm:@max-md:flex-col @sm:@max-lg:flex-col"`;
     const unsortedString = `<div class="@sm:@max-lg:flex-col @sm:@max-md:flex-col flex"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Container queries", () => {
     const sortedString = `<div class="flex @sm:flex @md:flex @lg:flex text-black group-hover:text-blue-500"`;
     const unsortedString = `<div class="@lg:flex group-hover:text-blue-500 flex @md:flex @sm:flex text-black"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("@container w arbitrary values", () => {
     const sortedString = `<div class="@container max-[600px]:bg-sky-300 min-[320px]:text-center">`;
     const unsortedString = `<div class="min-[320px]:text-center max-[600px]:bg-sky-300 @container">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Arbitrary values", () => {
     const sortedString = `<div className='bg-[#1a1a1a] w-[100px] h-[calc(100%-1rem)]' blah blah`;
     const unsortedString = `<div className='h-[calc(100%-1rem)] w-[100px] bg-[#1a1a1a]' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Arbitrary values with dynamic content", () => {
     const sortedString = `<div class="content-['Time:_12:30_PM'] before:content-[attr(data:time)]">`;
     const unsortedString = `<div class="before:content-[attr(data:time)] content-['Time:_12:30_PM']">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Special characters in arbitrary []", () => {
     const sortedString = `<div class="grid-cols-[minmax(0,_1fr)_50px] w-[calc(100%-theme('spacing.2'))]">`;
     const unsortedString = `<div class="w-[calc(100%-theme('spacing.2'))] grid-cols-[minmax(0,_1fr)_50px]">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Multiple negative values", () => {
     const sortedString = `<div class="-inset-x-4 -m-2 -skew-y-3 -translate-y-full">`;
     const unsortedString = `<div class="-skew-y-3 -translate-y-full -m-2 -inset-x-4">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Fractional values", () => {
     const sortedString = `<div class="gap-x-1/2 grid grid-cols-[1fr,2fr] w-2/3 translate-x-1/2">`;
     const unsortedString = `<div class="translate-x-1/2 w-2/3 gap-x-1/2 grid-cols-[1fr,2fr] grid">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Dot in class", () => {
     const sortedString = `class="bg-[url('image.jpg')] text-black"`;
     const unsortedString = `class="text-black bg-[url('image.jpg')]"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Negative margins", () => {
     const sortedString = `<div className='z-10 -mt-5 -mb-5' blah blah`;
     const unsortedString = `<div className='-mb-5 z-10 -mt-5' blah blah`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Style vars", () => {
     const sortedString = `<div class="bg-[var(--my-color)] text-black"></div>`;
     const unsortedString = `<div class="text-black bg-[var(--my-color)]"></div>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Custom boolean data attributes", () => {
     const sortedString = `<div data-current class="bg-black opacity-75 data-current:opacity-100">`;
     const unsortedString = `<div data-current class="data-current:opacity-100 bg-black opacity-75">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("not variant", () => {
     const sortedString = `<div class="bg-black hover:opacity-100 not-hover:opacity-75">`;
     const unsortedString = `<div class="not-hover:opacity-75 hover:opacity-100 bg-black">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("not variant w prefix", () => {
     const sortedString = `<div class="tw:bg-black tw-hover:opacity-100 tw-not-hover:opacity-75 banana apple">`;
     const unsortedString = `<div class="banana tw-not-hover:opacity-75 apple tw-hover:opacity-100 tw:bg-black">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("sizes", () => {
     const sortedString = `<div class="w-1/12 w-xs w-md hover:w-md w-2xl">`;
     const unsortedString = `<div class="w-md w-xs w-2xl w-1/12 hover:w-md">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("MDX syntax", () => {
     const sortedString = `<Component className="bg-yellow-100 text-yellow-800" />`;
     const unsortedString = `<Component className="text-yellow-800 bg-yellow-100" />`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("MDX markdown syntax", () => {
@@ -410,10 +293,7 @@ This is a **bold** paragraph.
 This is a **bold** paragraph.
 <Component className="flex-col flex">mdx</Component>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Fragments", () => {
@@ -428,10 +308,7 @@ This is a **bold** paragraph.
 </>
 `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("EJS syntax", () => {
@@ -442,20 +319,14 @@ This is a **bold** paragraph.
         <p class="text-sm text-gray-700">Item <%= i %></p>
       <% } %>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Angular syntax", () => {
     const sortedString = `<div class="bg-blue-500 text-white"`;
     const unsortedString = `<div class="text-white bg-blue-500"`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Elixir syntax", () => {
@@ -482,50 +353,35 @@ This is a **bold** paragraph.
     end
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Phoenix syntax", () => {
     const sortedString = `<span class="bg-blue-500 text-white" id="counter"><%= @counter %></span>`;
     const unsortedString = `<span class="text-white bg-blue-500" id="counter"><%= @counter %></span>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Leptos syntax", () => {
     const sortedString = `<button class="flex flex-row" on:click=on_click>"Welcome to Leptos!"</button>`;
     const unsortedString = `<button class="flex-row flex" on:click=on_click>"Welcome to Leptos!"</button>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Yew syntax", () => {
     const sortedString = `<button class="bg-blue-500 text-white" onclick={ctx.link().callback(|_| Msg::Random)}>{ "Random" }</button>`;
     const unsortedString = `<button class="text-white bg-blue-500" onclick={ctx.link().callback(|_| Msg::Random)}>{ "Random" }</button>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("PHP syntax", () => {
     const sortedString = `<button class="bg-blue-500 text-white" onclick="<?php echo $link; ?>"><?php echo $label; ?></button>`;
     const unsortedString = `<button class="text-white bg-blue-500" onclick="<?php echo $link; ?>"><?php echo $label; ?></button>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("PHP Laravel syntax", () => {
@@ -536,10 +392,7 @@ This is a **bold** paragraph.
         Increment Count
     </button>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("PHP Symfony Twig syntax", () => {
@@ -550,10 +403,7 @@ This is a **bold** paragraph.
        <a href="{{ path('homepage') }}" class="px-4 block">Home</a>
     {% endblock %}`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Django html syntax", () => {
@@ -565,10 +415,7 @@ This is a **bold** paragraph.
     <a href="{% url 'homepage' %}" class="px-4 block">Home</a>
   {% endblock %}`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("C# Razor syntax", () => {
@@ -581,10 +428,7 @@ This is a **bold** paragraph.
     @Model
 </div>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("C# Razor @ syntax", () => {
@@ -599,10 +443,7 @@ This is a **bold** paragraph.
     <div class="mb-2 rounded p-2 @color">Item @i</div>
 }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("PHP Blade syntax", () => {
@@ -616,20 +457,14 @@ This is a **bold** paragraph.
           <x-alert type="success" message="This is a success alert!" class="text-white bg-blue-500" />
       @endsection`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Svelte syntax", () => {
     const sortedString = `<div class:isActive={isActive && !isDisabled} class="bg-blue-400 bg-blue-500 text-white">`;
     const unsortedString = `<div class:isActive={isActive && !isDisabled} class="bg-blue-400 text-white bg-blue-500">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Rails erb helper tag", () => {
@@ -638,10 +473,7 @@ This is a **bold** paragraph.
     const sortedString = `<%= f.label :name, class: "bg-blue-400 bg-blue-500 text-white" %>`;
     const unsortedString = `<%= f.label :name, class: "bg-blue-500 text-white bg-blue-400" %>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Rails erb helper tag with ()", () => {
@@ -650,10 +482,7 @@ This is a **bold** paragraph.
     const sortedString = `<%= form_with(model: @user, class: 'bg-pink-500 text-white') do |f| %>`;
     const unsortedString = `<%= form_with(model: @user, class: 'text-white bg-pink-500') do |f| %>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Rails rb view component", () => {
@@ -662,10 +491,7 @@ This is a **bold** paragraph.
     const sortedString = `form_with model: @user, class: 'bg-pink-500 text-white' do |f|`;
     const unsortedString = `form_with model: @user, class: 'text-white bg-pink-500' do |f|`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Ruby class: in parenthesis", () => {
@@ -674,10 +500,7 @@ This is a **bold** paragraph.
     const sortedString = `tag.svg(class: "flex flex-col size-full -rotate-90", viewBox: "0 0 36 36", xmlns: "http://www.w3.org/2000/svg") do`;
     const unsortedString = `tag.svg(class: "size-full flex-col -rotate-90 flex", viewBox: "0 0 36 36", xmlns: "http://www.w3.org/2000/svg") do`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Rails rb view component with ()", () => {
@@ -686,10 +509,7 @@ This is a **bold** paragraph.
     const sortedString = `form_with(model: @user, class: 'bg-pink-500 text-white') do |f|`;
     const unsortedString = `form_with(model: @user, class: 'text-white bg-pink-500') do |f|`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Rails rb view component with special syntax", () => {
@@ -698,10 +518,7 @@ This is a **bold** paragraph.
     const sortedString = `has_dom_class -> { 'bg-pink-500 text-white' }`;
     const unsortedString = `has_dom_class -> { 'text-white bg-pink-500' }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Liquid syntax", () => {
@@ -720,20 +537,14 @@ This is a **bold** paragraph.
   {% endfor %}
 </ul>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Liquid conditional syntax", () => {
     const sortedString = `<div {% if block.settings.highlight %}class="flex flex-col bg-yellow-100"{% endif %}>`;
     const unsortedString = `<div {% if block.settings.highlight %}class="bg-yellow-100 flex-col flex"{% endif %}>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Tailwind merge concat strings", () => {
@@ -748,10 +559,7 @@ This is a **bold** paragraph.
       "      container: twMerge('flex-col flex'),\n" +
       "    }";
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Tailwind merge multi strings", () => {
@@ -761,10 +569,7 @@ This is a **bold** paragraph.
     const unsortedString =
       "twMerge('hover:bg-dark-red bg-red', 'p-3 bg-[#B91C1C]')";
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("Tailwind merge `", () => {
@@ -772,30 +577,21 @@ This is a **bold** paragraph.
 
     const unsortedString = "twMerge(`lg:grid-cols-[1fr,auto] grid-cols-2`)";
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`Inside brackets twMerge(`, () => {
     const sortedString = `<aside className={twMerge('flex p-4')}>`;
     const unsortedString = `<aside className={twMerge(' p-4     flex    ')}>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`Inside brackets w space twMerge(`, () => {
     const sortedString = `<aside className={ twMerge('flex p-4')}>`;
     const unsortedString = `<aside className={ twMerge(' p-4     flex    ')}>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`Newline twMerge(`, () => {
@@ -810,30 +606,21 @@ This is a **bold** paragraph.
       ),
     };`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`cn(`, () => {
     const sortedString = `<div className={cn("relative w-full overflow-auto", wrapperClassName)}>`;
     const unsortedString = `<div className={cn("relative overflow-auto w-full", wrapperClassName)}>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`Complex cn(`, () => {
     const sortedString = `  return <tfoot className={cn("bg-muted/50 border-t last:[&>tr]:border-b-0", className)} {...rest} />;`;
     const unsortedString = `  return <tfoot className={cn("bg-muted/50 border-t last:[&>tr]:border-b-0", className)} {...rest} />;`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`Newline cn(`, () => {
@@ -852,10 +639,7 @@ className
 {...props}
 />]`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test(`Complex newline clsx(`, () => {
@@ -878,10 +662,7 @@ className
         )}
       ></span>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("clsx multi", () => {
@@ -891,30 +672,21 @@ className
     const sortedString = `clsx('bg-blue-500 text-base', { 'bg-blue-700 text-gray-100': isHovering })`;
     const unsortedString = `clsx('text-base bg-blue-500', { 'bg-blue-700 text-gray-100': isHovering })`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("clsx", () => {
     const sortedString = `clsx('bg-blue-500 text-base')`;
     const unsortedString = `clsx('text-base           bg-blue-500     ')`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("clsx kitchen sink", () => {
     const sortedString = `clsx('bg-pink-500 text-black', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya')`;
     const unsortedString = `clsx('text-black bg-pink-500', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya')`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("cva syntax multi", () => {
@@ -926,10 +698,7 @@ className
     const sortedString = `cva('bg-blue-500 text-white', { 'bg-blue-700 text-gray-100': isHovering })`;
     const unsortedString = `cva('text-white bg-blue-500', { 'bg-blue-700 text-gray-100': isHovering })`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("cva", () => {
@@ -952,20 +721,14 @@ className
       },
     })`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("allow _ prefix for ignored classes", () => {
     const sortedString = `<div class="flex _flex-col justify-center gap-6 bg-white _shadow-2xl p-8 border _hover:border-yellow-400 rounded-4xl w-lg custom_flex">`;
     const unsortedString = `<div class="_shadow-2xl justify-center custom_flex gap-6 _hover:border-yellow-400 bg-white _flex-col p-8 border flex rounded-4xl w-lg">`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 });
 
@@ -984,10 +747,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("nested css", () => {
@@ -1002,10 +762,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("nested scss", () => {
@@ -1032,10 +789,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("style block", () => {
@@ -1060,10 +814,7 @@ suite("@apply Sorting", () => {
     </style>
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("multiple applys", () => {
@@ -1082,10 +833,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("media queries", () => {
@@ -1112,10 +860,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("pseudo-classes and modifiers", () => {
@@ -1142,10 +887,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("complex selectors", () => {
@@ -1176,10 +918,7 @@ suite("@apply Sorting", () => {
     }
     `;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("important modifier", () => {
@@ -1192,10 +931,7 @@ suite("@apply Sorting", () => {
       @apply !bg-blue-500 text-white;
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("complex arbitrary values", () => {
@@ -1208,10 +944,7 @@ suite("@apply Sorting", () => {
       @apply bg-[rgb(0,0,0)] text-[clamp(1rem,2vw,1.5rem)];
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("apply and class sort", () => {
@@ -1226,10 +959,7 @@ suite("@apply Sorting", () => {
       }
       </style>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("mixed CSS and @apply", () => {
@@ -1250,10 +980,7 @@ suite("@apply Sorting", () => {
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("css variables", () => {
@@ -1298,10 +1025,7 @@ suite("@apply Sorting", () => {
       }
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("realistic component styles", () => {
@@ -1362,10 +1086,7 @@ suite("@apply Sorting", () => {
       }
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("nested @apply with @if", () => {
@@ -1392,10 +1113,7 @@ suite("@apply Sorting", () => {
       }
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("@apply with custom @", () => {
@@ -1426,10 +1144,7 @@ suite("@apply Sorting", () => {
       }
     }`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 
   test("mixed class formats", () => {
@@ -1448,9 +1163,6 @@ suite("@apply Sorting", () => {
       className={clsx('bg-blue-500 hover:bg-blue-600 hover:text-white', className)}>
     </div>`;
 
-    assert.strictEqual(
-      sortHelper(unsortedString),
-      sortedString
-    );
+    assert.strictEqual(sortHelper(unsortedString), sortedString);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type SortOptions =
+  | {
+      mode: "extension";
+      classesMap: {
+        [property: string]: number;
+      };
+      pseudoSortOrder: string[];
+      sectionOrder: string[];
+    }
+  | { mode: "official"; sorter: any };


### PR DESCRIPTION
Option to override native sort settings with the official prettier plugin's sorting api

- adds dependency on prettier-plugin-tailwindcss
- refactored sort logic to accept conditional `sortOptions`